### PR TITLE
[BL-831] Use all the 245 fields when no title is found.

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -70,8 +70,7 @@ to_field "title_uniform_t", extract_marc_with_flank("130adfklmnoprs:240adfklmnop
 
 to_field "work_access_point", extract_work_access_point
 
-ATOZ = ("a".."z").to_a.join("")
-ATOU = ("a".."u").to_a.join("")
+A_TO_U = ("a".."u").to_a.join("")
 to_field "title_addl_t",
   extract_marc(%W{
     210ab
@@ -174,10 +173,10 @@ to_field "genre_t", extract_genre_display
 to_field "genre_full_facet", extract_genre_display
 
 to_field "subject_t", extract_marc_with_flank(%W(
-  600#{ATOU}
-  610#{ATOU}
-  611#{ATOU}
-  630#{ATOU}
+  600#{A_TO_U}
+  610#{A_TO_U}
+  611#{A_TO_U}
+  630#{A_TO_U}
   647acdg
   650abcde
   653a:654abcde

--- a/spec/fixtures/marc_files/title_statement_examples.xml
+++ b/spec/fixtures/marc_files/title_statement_examples.xml
@@ -22,4 +22,10 @@
       <subfield code="c">a Janus Films release ; produced by Keinosuke Kubo ; screenplay by Ichoro Ikeda Tadaaki Yamazaki ; directed by Seijun Suzuki.</subfield>
     </datafield>
   </record>
+  <record>
+    <!-- 3. 245 only h field -->
+    <datafield ind1="0" ind2="4" tag="245">
+      <subfield code="h">[video recording]</subfield>
+    </datafield>
+  </record>
 </collection>

--- a/spec/traject_indexer_spec.rb
+++ b/spec/traject_indexer_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe Traject::Macros::Custom do
         expect(subject.map_record(records[2])).to eq(expected)
       end
     end
+
+    context "title not found with limited selection" do
+      it "uses 245A_TO_Z selection" do
+        expected = { "title_statement_display" => ["[video recording]"] }
+        expect(subject.map_record(records[3])).to eq(expected)
+      end
+    end
   end
 
   describe "#extract_creator" do


### PR DESCRIPTION
When no title is found using the minimal selection of 245 sub fields,
then create a title from all the sub fields a through z.