### PR TITLE
BL-974 Remove unused fields from Traject

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -54,8 +54,9 @@ to_field "language_display", extract_lang("008[35-37]:041a:041d:041e:041g:041j")
 to_field("format", marc_formats, &normalize_format)
 
 # Title fields
-
+# Used on the full record page
 to_field "title_statement_display", extract_title_statement
+# Used in the catalog search results display
 to_field "title_truncated_display", extract_title_statement, &truncate(300)
 to_field "title_statement_vern_display", extract_marc("245abcfgknps", alternate_script: :only)
 to_field "title_uniform_display", extract_marc("130adfklmnoprs:240adfklmnoprs:730ail", alternate_script: false)
@@ -150,6 +151,7 @@ to_field "note_restrictions_display", extract_marc("506abcde")
 to_field "note_references_display", extract_marc("510abc")
 to_field "note_summary_display", extract_marc("520ab")
 to_field "note_cite_display", extract_marc("524a")
+
 # Note Copyright should not display if ind1 = 0.  This ensures that it works if the value is unassigned or 1
 to_field "note_copyright_display", extract_marc("540a:542|1*|abcdefghijklmnopqr3:542| *|abcdefghijklmnopqr3")
 to_field "note_bio_display", extract_marc("545abu")
@@ -189,13 +191,6 @@ to_field "call_number_t", extract_marc_with_flank("HLDhi")
 to_field "call_number_alt_display", extract_marc("ITMjk")
 to_field "call_number_alt_t", extract_marc_with_flank("ITMjk")
 to_field "library_facet", extract_library
-to_field "library_location_display", extract_library_shelf_call_number
-
-# Call Number fields
-to_field "lc_callnum_display", extract_marc("050ab", first: true)
-to_field("lc_1letter_facet", extract_marc("050ab", first: true, translation_map: "callnumber_map"), &first_letters_only)
-to_field("lc_alpha_facet", extract_marc("050a", first: true), &normalize_lc_alpha)
-to_field "lc_b4cutter_facet", extract_marc("050a", first: true)
 
 # URL Fields
 to_field "url_more_links_display", extract_url_more_links
@@ -217,7 +212,6 @@ to_field("alt_issn_display", extract_marc("022lz:776x", separator: nil), &normal
 to_field("lccn_display", extract_marc("010ab", separator: nil), &normalize_lccn)
 to_field "pub_no_display", extract_marc("028ab")
 to_field "sudoc_display", extract_marc("086|0*|a")
-to_field "diamond_id_display", extract_marc("907a")
 to_field "gpo_display", extract_marc("074a")
 to_field "oclc_number_display", extract_oclc_number
 to_field "alma_mms_display", extract_marc("001")

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -448,19 +448,6 @@ module Traject
         end
       end
 
-      def extract_library_shelf_call_number
-        lambda do |rec, acc|
-          rec.fields(["HLD"]).each do |field|
-            if field["b"] != "RES_SHARE"
-              location = Traject::TranslationMap.new("libraries_map")[field["b"]]
-              shelf = Traject::TranslationMap.new("shelf_map")[field["c"]]
-              call_number = field["h"]
-              acc << "#{location} (#{shelf})\n(#{call_number})"
-            end
-          end
-        end
-      end
-
       def extract_pub_date
         lambda do |rec, acc|
           rec.fields(["008"]).each do |field|

--- a/lib/translation_maps/shelf_map.properties
+++ b/lib/translation_maps/shelf_map.properties
@@ -1,4 +1,0 @@
-stacks = Stacks
-remote = Remote
-p_remote = Remote
-rarestacks = Reading Room


### PR DESCRIPTION
- Removes the following fields that we are not using: 
  - lc_callnum_display
  - lc_1letter_facet
  - lc_alpha_facet
  - lc_b4cutter_facet
  - library_location_display
  - diamond_id_display
- The library_location_display field was created as part of the twilio integration that we did not end up using.  This also removes the custom extract method and translation file related to the unused field