### PR TITLE
Add dot_properties wrapper.

### DIFF
--- a/lib/cob_index.rb
+++ b/lib/cob_index.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "cob_index/version"
+require "cob_index/dot_properties"
 require "traject"
 
 module CobIndex

--- a/lib/cob_index/dot_properties.rb
+++ b/lib/cob_index/dot_properties.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "dot_properties"
+
+module CobIndex
+  class DotProperties
+    def self.load(name)
+      ::DotProperties.load(File.dirname(__FILE__) + "/../translation_maps/#{name}.properties")
+    end
+  end
+end

--- a/spec/cob_index/dot_properties_spec.rb
+++ b/spec/cob_index/dot_properties_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe CobIndex::DotProperties do
+
+  describe "#load" do
+    it "loads local properties" do
+      properties = CobIndex::DotProperties.load("libraries_map")
+      expect(properties["MAIN"]).to eq("Charles Library")
+    end
+  end
+end


### PR DESCRIPTION
Allow use of our dot_properties config so that we don't have to maintain
these files across multiple repositories.