### PR TITLE
Do not error out on 409.

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -2,6 +2,7 @@
 
 require "yaml"
 require "cob_index"
+require "cob_index/solr_json_writer"
 
 if File.exist? "config/blacklight.yml"
   solr_config = YAML.load_file("config/blacklight.yml")[(ENV["RAILS_ENV"] || "development")]
@@ -43,6 +44,7 @@ settings do
   provide "solr_writer.commit_timeout", (15 * 60)
   provide "solr.url", solr_url
   provide "solr_writer.commit_on_close", "false"
+  provide "writer_class_name", "CobIndex::SolrJsonWriter"
 end
 
 each_record do |record, context|

--- a/lib/cob_index/solr_json_writer.rb
+++ b/lib/cob_index/solr_json_writer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
+  VALID_RESPONSE_CODES = [200, 409]
+
+  # Overries parent::send_single in order to to not throw error on 409.
+  # Send a single context to Solr, logging an error if need be
+  # @param [Traject::Indexer::Context] c The context whose document you want to send
+  def send_single(c)
+    logger.debug("#{self.class.name}: sending single record to Solr: #{c.output_hash}")
+
+    json_package = JSON.generate([c.output_hash])
+    begin
+      post_url = solr_update_url_with_query(@solr_update_args)
+      resp = @http_client.post post_url, json_package, "Content-type" => "application/json"
+
+      unless VALID_RESPONSE_CODES.include?(resp.status)
+        raise BadHttpResponse.new("Unexpected HTTP response status #{resp.status} from POST #{post_url}", resp)
+      end
+
+      if resp.status == 409
+        # log 409s responses even if ignoring them.
+        logger.warn "Could not add record #{c.record_inspect} do to version conflict: Solr error response 409."
+      end
+
+      # Catch Timeouts and network errors -- as well as non-200 http responses --
+      # as skipped records, but otherwise allow unexpected errors to propagate up.
+    rescue *skippable_exceptions => exception
+      msg = if exception.kind_of?(BadHttpResponse)
+        "Solr error response: #{exception.response.status}: #{exception.response.body}"
+      else
+        Traject::Util.exception_to_log_message(exception)
+      end
+
+      logger.error "Could not add record #{c.record_inspect}: #{msg}"
+      logger.debug("\t" + exception.backtrace.join("\n\t")) if exception
+      logger.debug(c.source_record.to_s) if c.source_record
+
+      @skipped_record_incrementer.increment
+      if @max_skipped && (skipped_record_count > @max_skipped)
+        # re-raising in rescue means the last encountered error will be available as #cause
+        # on raised exception, a feature in ruby 2.1+.
+        raise MaxSkippedRecordsExceeded.new("#{self.class.name}: Exceeded maximum number of skipped records (#{@max_skipped}): aborting: #{exception.message}")
+      end
+    end
+  end
+end

--- a/spec/cob_index/solr_json_writer_spec.rb
+++ b/spec/cob_index/solr_json_writer_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "cob_index/solr_json_writer"
+
+RSpec.describe CobIndex::SolrJsonWriter do
+  let(:fake_http_client) { FakeHttpClient.new }
+  let(:strio) { StringIO.new }
+  let(:logger) { Logger.new(strio) }
+  let(:settings) { {
+    "id" => "doc_foo",
+    "key" => "value",
+    "solr.url" =>  "http://example.com/solr",
+    logger: logger,
+    "solr_json_writer.http_client" => fake_http_client,
+  } }
+
+  let(:subject) { CobIndex::SolrJsonWriter.new(settings) }
+
+  describe "#send_single" do
+    context "500 hundred response" do
+      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 500; f }
+
+      it "raises on non-200-409 http response" do
+        expect { subject.send_single(context_with({})) }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "409 response" do
+      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 409; f }
+
+      it "does not raise error for 409 http response" do
+        expect { subject.send_single(context_with({})) }.not_to raise_error(RuntimeError)
+      end
+
+      it "reports 409 errors." do
+        subject.send_single(context_with("id" => "foo_bar"))
+        expect(strio.string).to match(/WARN -- : Could not add record <output_id:foo_bar>/)
+      end
+    end
+
+
+    context "200 response" do
+      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 200; f }
+
+      it "does not raise error for 200 http response " do
+        expect { subject.send_single(context_with({})) }.not_to raise_error(RuntimeError)
+      end
+
+    end
+
+    context "Max skipped records exceeded" do
+      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 3; f }
+
+      let(:settings) { {
+        "id" => "doc_foo",
+        "key" => "value",
+        "solr_writer.max_skipped" => 0,
+        "solr.url" =>  "http://example.com/solr",
+        "solr_json_writer.http_client" => fake_http_client,
+      } }
+
+      it "throws a maxed skipped record exceeded error" do
+        expect { subject.send_single(context_with({})) }.to raise_error(Traject::SolrJsonWriter::MaxSkippedRecordsExceeded)
+      end
+    end
+  end
+
+
+  def context_with(hash)
+    Traject::Indexer::Context.new(output_hash: hash)
+  end
+
+  class FakeHttpClient
+    # Always reply with this status, normally 200, can
+    # be reset for testing error conditions.
+    attr_accessor :response_status
+
+    def initialize(*args)
+      @post_args = []
+      @get_args  = []
+      @response_status = 200
+      @mutex = Monitor.new
+    end
+
+    def post(*args)
+      @mutex.synchronize do
+        @post_args << args
+      end
+
+      resp = HTTP::Message.new_response("")
+      resp.status = self.response_status
+
+      return resp
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #28

Allow logging of 409 errors but do not include them in calculus to error
out the ingest process. This makes it possible to enable versioning on
solr while still monitoring when a record gets rejected to the
versioning control.