### PR TITLE
Add configurable optimization for versioned batched updates.

### DIFF
--- a/lib/cob_index/solr_json_writer.rb
+++ b/lib/cob_index/solr_json_writer.rb
@@ -65,6 +65,8 @@ class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
   # @return [Hash] a dictionary where keys are doc ids and values are record_update_date.
   def get_record_update_dates(batch)
     ids = batch.map { |c| c.output_hash["id"] }
+      .flatten
+
     resp = @http_client.get(solr_select_url,
       fq: "id:(#{ids.join(" ")})",
       fl: "id, record_update_date",
@@ -96,7 +98,6 @@ class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
       context = c.output_hash
       context_update_date = context[:record_update_date] ||
         context["record_update_date"]
-
       # Output hash values can be in arrays.
       if context_update_date.is_a? Array
         context_update_date = context_update_date.first
@@ -105,7 +106,6 @@ class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
       context_update_date = Time.parse(context_update_date) rescue nil
 
       id = context[:id] || context["id"]
-
       if id.is_a? Array
         id = id.first
       end

--- a/lib/cob_index/solr_json_writer.rb
+++ b/lib/cob_index/solr_json_writer.rb
@@ -108,8 +108,8 @@ class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
         acc << c
 
       # Prevent 409 error by not pushing older context.
-      elsif context_update_date < solr_record_update_date
-        logger.info "Filtering out context because it is older than the record in the database id:#{id}, solr_date: #{solr_record_update_date}, context_date: #{context_update_date}"
+      elsif context_update_date <= solr_record_update_date
+        logger.info "Filtering out context because it is not newer than the record in the database id:#{id}, solr_date: #{solr_record_update_date}, context_date: #{context_update_date}"
 
         acc
       else

--- a/lib/cob_index/solr_json_writer.rb
+++ b/lib/cob_index/solr_json_writer.rb
@@ -124,7 +124,7 @@ class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
       if settings["solr.select_url"]
         check_solr_update_url(settings["solr.select_url"])
       else
-        self.determine_solr_update_url.gsub("/update", "/select")
+        self.determine_solr_update_url.gsub(/\/update(\/json)?/, "/select")
       end
   end
 end

--- a/spec/cob_index/solr_json_writer_spec.rb
+++ b/spec/cob_index/solr_json_writer_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe CobIndex::SolrJsonWriter do
       } }
 
       it "derives the select_url" do
-        expect(subject.solr_select_url).to eq("http://example.com/solr/collection/select/json")
+        expect(subject.solr_select_url).to eq("http://example.com/solr/collection/select")
       end
     end
   end

--- a/spec/cob_index/solr_json_writer_spec.rb
+++ b/spec/cob_index/solr_json_writer_spec.rb
@@ -235,6 +235,15 @@ RSpec.describe CobIndex::SolrJsonWriter do
         expect(subject.select_latest_records(batch, update_dates)).to eq([])
       end
     end
+
+    context "context hash values in in arrays." do
+      let(:context_hash) { { "id" => ["foo"], "record_update_date" => ["2019-12-01Z00:00:00"] } }
+      let(:update_dates) { { "foo" => "2019-12-01Z00:00:01" } }
+
+      it "does filter out context (with indifferent access)" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq([])
+      end
+    end
   end
 
   describe "solr_select_url" do

--- a/spec/cob_index/solr_json_writer_spec.rb
+++ b/spec/cob_index/solr_json_writer_spec.rb
@@ -209,7 +209,21 @@ RSpec.describe CobIndex::SolrJsonWriter do
 
       it "should log that it's filtering out the context" do
         subject.select_latest_records(batch, update_dates)
-        expect(strio.string).to match(/INFO -- : Filtering out context because it is older than the record in the database id:foo/)
+        expect(strio.string).to match(/INFO -- : Filtering out context because it is not newer than the record in the database id:foo/)
+      end
+    end
+
+    context "record and context have the same update date" do
+      let(:context_hash) { { id: "foo", record_update_date: "2019-12-01Z00:00:00" } }
+      let(:update_dates) { { "foo" => "2019-12-01Z00:00:00" } }
+
+      it "does filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq([])
+      end
+
+      it "should log that it's filtering out the context" do
+        subject.select_latest_records(batch, update_dates)
+        expect(strio.string).to match(/INFO -- : Filtering out context because it is not newer than the record in the database id:foo/)
       end
     end
 

--- a/spec/cob_index/solr_json_writer_spec.rb
+++ b/spec/cob_index/solr_json_writer_spec.rb
@@ -3,30 +3,44 @@
 require "cob_index/solr_json_writer"
 
 RSpec.describe CobIndex::SolrJsonWriter do
-  let(:fake_http_client) { FakeHttpClient.new }
-  let(:strio) { StringIO.new }
-  let(:logger) { Logger.new(strio) }
+  let(:subject) { CobIndex::SolrJsonWriter.new(settings) }
   let(:settings) { {
     "id" => "doc_foo",
     "key" => "value",
     "solr.url" =>  "http://example.com/solr",
     logger: logger,
-    "solr_json_writer.http_client" => fake_http_client,
+    "solr_json_writer.http_client" => http_client,
   } }
+  let(:logger) { Logger.new(strio) }
+  let(:strio) { StringIO.new }
+  let(:http_client) { double(HTTPClient) }
 
-  let(:subject) { CobIndex::SolrJsonWriter.new(settings) }
+
+  let(:resp) {
+    r = HTTP::Message.new_response(solr_resp_message)
+    r.status = response_status
+    r
+  }
+  let(:solr_resp_message) { "" }
+  let(:response_status) { 200 }
+  let(:contxt) { context_with(context_hash) }
+
+  before(:each) do
+    allow(http_client).to receive(:post) { resp }
+    allow(http_client).to receive(:get) { resp }
+  end
 
   describe "#send_single" do
-    context "500 hundred response" do
-      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 500; f }
+    context "response status is 500" do
+      let(:response_status) { 500 }
 
       it "raises on non-200-409 http response" do
         expect { subject.send_single(context_with({})) }.to raise_error(RuntimeError)
       end
     end
 
-    context "409 response" do
-      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 409; f }
+    context "response status is 409" do
+      let(:response_status) { 409 }
 
       it "does not raise error for 409 http response" do
         expect { subject.send_single(context_with({})) }.not_to raise_error(RuntimeError)
@@ -38,25 +52,20 @@ RSpec.describe CobIndex::SolrJsonWriter do
       end
     end
 
-
-    context "200 response" do
-      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 200; f }
-
+    context "response status is 200 (default)" do
       it "does not raise error for 200 http response " do
         expect { subject.send_single(context_with({})) }.not_to raise_error(RuntimeError)
       end
-
     end
 
     context "Max skipped records exceeded" do
-      let(:fake_http_client) { f = FakeHttpClient.new; f.response_status = 3; f }
-
+      let(:response_status) { 500 }
       let(:settings) { {
         "id" => "doc_foo",
         "key" => "value",
         "solr_writer.max_skipped" => 0,
         "solr.url" =>  "http://example.com/solr",
-        "solr_json_writer.http_client" => fake_http_client,
+        "solr_json_writer.http_client" => http_client,
       } }
 
       it "throws a maxed skipped record exceeded error" do
@@ -65,33 +74,190 @@ RSpec.describe CobIndex::SolrJsonWriter do
     end
   end
 
+  describe "#send_batch" do
+    let(:batch) { [contxt] }
+    let(:context_hash) { { id: "foo" } }
+
+    before(:each) do
+      allow(subject).to receive(:get_record_update_dates)
+      allow(subject).to receive(:select_latest_records) { batch }
+      subject.send_batch(batch)
+    end
+
+    context "solr_writer.optimize_batch_send is true" do
+      let(:settings) { {
+        "solr.url" => "http://example.com:8983/solr/collection",
+        "solr_json_writer.http_client" => http_client,
+        "solr_writer.optimize_batch_send" => true,
+      } }
+
+      it "calls optimizing methods" do
+        expect(subject).to have_received(:get_record_update_dates)
+        expect(subject).to have_received(:select_latest_records)
+      end
+    end
+
+    context "solr_writer.optimize_batch_send is not true" do
+      let(:settings) { {
+        "solr.url" => "http://example.com:8983/solr/collection",
+        "solr_json_writer.http_client" => http_client,
+      } }
+
+      it "does not call optimizing methods" do
+        expect(subject).not_to have_received(:get_record_update_dates)
+        expect(subject).not_to have_received(:select_latest_records)
+      end
+    end
+  end
+
+  describe "#get_record_update_dates" do
+    let(:context1) {
+      context_with(id: "foo", record_update_date: "2019-12-01T00:00:00")
+    }
+    let(:context2) {
+      context_with(id: "bar", record_update_date: "2019-12-01T00:00:01")
+    }
+    let(:batch) { [context1, context2] }
+
+    context "solr responsds with non 200 status code" do
+      let(:response_status) { 500 }
+
+      it "returns an empty hash" do
+        expect(subject.get_record_update_dates(batch)).to eq({})
+      end
+
+      it "logs that an error happened" do
+        subject.get_record_update_dates(batch)
+        expect(strio.string).to match(/ERROR -- : Error in getting solr update date info for batch/)
+      end
+    end
+
+    context "solr responsds with correct data " do
+      let(:solr_resp_message) { {
+        response: { docs: [
+          { id: "foo", record_update_date: "2019-12-01T00:00:00" },
+          { id: "bar", record_update_date: "2019-12-01T00:00:00" },
+        ] }
+      }.to_json }
+
+      it "returns hash of record ids matched to record update dates" do
+        update_dates = {
+          "foo" => "2019-12-01T00:00:00",
+          "bar" => "2019-12-01T00:00:00",
+        }
+        expect(subject.get_record_update_dates(batch)).to eq(update_dates)
+      end
+    end
+  end
+
+  describe "#select_latest_records" do
+    let(:batch) { [contxt] }
+    let(:solr_resp_message) { { response: { docs: [ record ] } }.to_json }
+
+    context "context has no record_update_date field" do
+      let(:context_hash) { { id: "foo" } }
+      let(:update_dates) { { "foo" => "2019-12-01T00:00:00" } }
+
+      it "does not filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq(batch)
+      end
+    end
+
+    context "context has malformed record_update_date field" do
+      let(:context_hash) { { id: "foo", record_update_date: "bar" } }
+      let(:update_dates) { { "foo" => "2019-12-01T00:00:00" } }
+
+      it "does not filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq(batch)
+      end
+    end
+
+    context "record has no record_update_date field" do
+      let(:context_hash) { { id: "foo", record_update_date: "2019-12-01T00:00:00" } }
+      let(:update_dates) { { "foo" => nil } }
+
+      it "does not filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq(batch)
+      end
+    end
+
+    context "record has malformed record_update_date field" do
+      let(:context_hash) { { id: "foo", record_update_date: "2019-12-01T00:00:00" } }
+      let(:update_dates) { { "foo" => "bar" } }
+
+      it "does not filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq(batch)
+      end
+    end
+
+    context "context's record_update_date is latest" do
+      let(:context_hash) { { id: "foo", record_update_date: "2019-12-01T00:00:01" } }
+      let(:update_dates) { { "foo" => "2019-12-01T00:00:00" } }
+
+      it "does not filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq(batch)
+      end
+    end
+
+    context "record's record_update_date is latest" do
+      let(:context_hash) { { id: "foo", record_update_date: "2019-12-01Z00:00:00" } }
+      let(:update_dates) { { "foo" => "2019-12-01Z00:00:01" } }
+
+      it "does filter out context" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq([])
+      end
+
+      it "should log that it's filtering out the context" do
+        subject.select_latest_records(batch, update_dates)
+        expect(strio.string).to match(/INFO -- : Filtering out context because it is older than the record in the database id:foo/)
+      end
+    end
+
+    context "record's record_update_date is latest and keys are strings" do
+      let(:context_hash) { { "id" => "foo", "record_update_date" => "2019-12-01Z00:00:00" } }
+      let(:update_dates) { { "foo" => "2019-12-01Z00:00:01" } }
+
+      it "does filter out context (with indifferent access)" do
+        expect(subject.select_latest_records(batch, update_dates)).to eq([])
+      end
+    end
+  end
+
+  describe "solr_select_url" do
+    context "solr.select_url setting is defined with good URL"  do
+      let(:settings) { {
+        "solr.url" =>  "http://example.com/solr/collection",
+        "solr.select_url" => "http://example.com/solr/collection/myselect"
+      } }
+
+      it "uses the configured solr.select_url" do
+        expect(subject.solr_select_url).to eq("http://example.com/solr/collection/myselect")
+      end
+    end
+
+    context "solr.select_url setting is defined with bad URL"  do
+      let(:settings) { {
+        "solr.url" =>  "http://example.com/solr",
+        "solr.select_url" => "foobar"
+      } }
+
+      it "throws an error" do
+        expect { subject.solr_select_url }.to raise_error(ArgumentError)
+      end
+    end
+
+    context "solr.select_url not defined"  do
+      let(:settings) { {
+        "solr.url" =>  "http://example.com/solr/collection",
+      } }
+
+      it "derives the select_url" do
+        expect(subject.solr_select_url).to eq("http://example.com/solr/collection/select/json")
+      end
+    end
+  end
 
   def context_with(hash)
     Traject::Indexer::Context.new(output_hash: hash)
   end
-
-  class FakeHttpClient
-    # Always reply with this status, normally 200, can
-    # be reset for testing error conditions.
-    attr_accessor :response_status
-
-    def initialize(*args)
-      @post_args = []
-      @get_args  = []
-      @response_status = 200
-      @mutex = Monitor.new
-    end
-
-    def post(*args)
-      @mutex.synchronize do
-        @post_args << args
-      end
-
-      resp = HTTP::Message.new_response("")
-      resp.status = self.response_status
-
-      return resp
-    end
-  end
-
 end


### PR DESCRIPTION
When Solr versioning is enabled the default traject json writer often
has to break up the batched update into many single updates do to Solr
responding with 409 errors.

This commit adds a configurable optimization option which when enabled
will make a call to Solr to find the record update dates of records that
are about to be batched processed. Then it uses this information to
filter out the batched records if they are older than the Solr records.
Thus, we avoid Solr responding with 409 and avoid breaking up the
batched update into many single updates.

The reason this is configurable is because we wouldn't need or want to
do this for full re-indexing jobs which would happen on a clean Solr
collection.

This optimization does not guarantee to work when multiple workers are
indexing simultaneously.  But, it's still better than nothing.