### PR TITLE
Removing Commits from Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ cob_index ingest $path_to_file
 `$path_file` can also be a URL.
 
 
+### Ingest switches
+`--commit` If this switch is passed (`cob_index ingest --commit`), then cob_index will send commit at end of ingest process.
+
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/exe/cob_index
+++ b/exe/cob_index
@@ -17,10 +17,15 @@ class App
   desc "Ingest files into solr endpoint using tul_cob traject config"
   arg_name "Describe arguments to ingest here"
   command :ingest do |c|
+    c.desc "Commit docs after ingest process closes."
+    c.switch ["commit"], default_value: false
+
     c.desc "Ingest files into SOLR_URL using tul_cob traject config"
     c.action do |global_options, options, args|
+      opts = {}
+      opts.merge!(commit: options[:commit])
 
-      CobIndex::CLI.ingest
+      CobIndex::CLI.ingest(opts)
     end
   end
 

--- a/lib/cob_index.rb
+++ b/lib/cob_index.rb
@@ -7,7 +7,7 @@ require "traject"
 module CobIndex
   module CLI
     def self.ingest
-      indexer = Traject::Indexer::MarcIndexer.new("solr_writer.commit_on_close": true)
+      indexer = Traject::Indexer::MarcIndexer.new("solr_writer.commit_on_close": false)
       indexer.load_config_file("#{File.dirname(__FILE__)}/cob_index/indexer_config.rb")
       indexer.process(StringIO.new(open(ARGV[0]).read))
     end

--- a/lib/cob_index.rb
+++ b/lib/cob_index.rb
@@ -6,8 +6,8 @@ require "traject"
 
 module CobIndex
   module CLI
-    def self.ingest
-      indexer = Traject::Indexer::MarcIndexer.new("solr_writer.commit_on_close": false)
+    def self.ingest(commit: false)
+      indexer = Traject::Indexer::MarcIndexer.new("solr_writer.commit_on_close": commit)
       indexer.load_config_file("#{File.dirname(__FILE__)}/cob_index/indexer_config.rb")
       indexer.process(StringIO.new(open(ARGV[0]).read))
     end

--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -40,10 +40,8 @@ settings do
   provide "marc_source.type", "xml"
   # set this to be non-negative if threshold should be enforced
   provide "solr_writer.max_skipped", -1
-  # extend commit timeout
-  provide "solr_writer.commit_timeout", (15 * 60)
   provide "solr.url", solr_url
-  provide "solr_writer.commit_on_close", "false"
+  provide "solr_writer.commit_on_close", false
   provide "writer_class_name", "CobIndex::SolrJsonWriter"
 
   if ENV["SOLR_AUTH_USER"] && ENV["SOLR_AUTH_PASSWORD"]

--- a/spec/cob_index_spec.rb
+++ b/spec/cob_index_spec.rb
@@ -24,5 +24,19 @@ RSpec.describe CobIndex do
       expect(@indexer).to receive(:load_config_file)
       expect(@indexer).to receive(:process)
     end
+
+    context "commit is not set" do
+      it "passes solr_writer.commit_on_close: false by default" do
+        expect(Traject::Indexer::MarcIndexer).to receive(:new).with("solr_writer.commit_on_close": false)
+      end
+    end
+
+
+    context "commit is true" do
+      it "passes solr_writer.commit_on_close: true" do
+        expect(Traject::Indexer::MarcIndexer).to receive(:new).with("solr_writer.commit_on_close": true)
+        CobIndex::CLI.ingest(commit: true)
+      end
+    end
   end
 end


### PR DESCRIPTION
What this PR attempts:
- removing commits being issued by the client. 

Questions related to this PR:
- this just manually changes this; should they be a flag, config value, or other? does such a flag or envvar exist that I can pass in with the cli (sorry if I missed it)
- we *may* be okay with ignoring this for the time being, though it is generally recommended in the solrcloud docs / discussions i've had to let solrcloud use its own autocommit settings.

Would appreciate feedback or thoughts on this PR about how to best proceed.