### PR TITLE
BL-1030 Finding aids logic

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -264,7 +264,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             unless f["u"].nil?
               if f.indicator2 == "2" || NOT_FULL_TEXT.match(label) || !rec.fields("PRT").empty? || f["u"].include?(ARCHIVE_IT_LINKS)
-                unless f["u"].include?("http://library.temple.edu") && f["u"].include?("scrc")
+                unless f["u"].include?("http://library.temple.edu") && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end
@@ -279,7 +279,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             if f.indicator1 == "4" && f.indicator2 == "2"
               unless f["u"].nil?
-                if f["u"].include?("http://library.temple.edu") && f["u"].include?("scrc")
+                if f["u"].include?("http://library.temple.edu") && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end

--- a/lib/cob_index/solr_json_writer.rb
+++ b/lib/cob_index/solr_json_writer.rb
@@ -20,7 +20,7 @@ class CobIndex::SolrJsonWriter < Traject::SolrJsonWriter
 
       if resp.status == 409
         # log 409s responses even if ignoring them.
-        logger.warn "Could not add record #{c.record_inspect} do to version conflict: Solr error response 409."
+        logger.warn "Could not add record #{c.record_inspect} due to version conflict: Solr error response 409."
       end
 
       # Catch Timeouts and network errors -- as well as non-200 http responses --

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -844,6 +844,22 @@ RSpec.describe Traject::Macros::Custom do
           end
         end
 
+        context "multiple 856 fields (ind1 = 4; ind2 = not 2) with  finding_aids exception" do
+          let(:record_text) { '
+            <record>
+              <!-- Links with temple url and finding_aids map to url_finding_aid_display -->
+              <datafield tag="856" ind1="4" ind2="2">
+                <subfield code="z">Finding aid</subfield>
+                <subfield code="u">http://library.temple.edu/finding_aids</subfield>
+              </datafield>
+            </record>
+          '}
+
+          it "does not include Temple finding_aids resources in url_more_links_display" do
+            expect(subject.map_record(record)).to eq({})
+          end
+        end
+
         context "single 856 field (ind1 = 4; ind2 = not 2) with exceptions" do
           let(:record_text) { '
             <record>
@@ -926,9 +942,26 @@ RSpec.describe Traject::Macros::Custom do
           </record>
         ' }
 
-        it "it does not map to url_finding_aid_display " do
+        it "it does map to url_finding_aid_display(scrc)" do
           expect(subject.map_record(record)).to eq(
             "url_finding_aid_display" => [ { title: "Finding aid", url: "http://library.temple.edu/scrc" }.to_json ])
+        end
+      end
+
+      context "856 fields with finding_aids exception" do
+        let(:record_text) { '
+          <record>
+            <!-- Links with temple url and finding_aids map to url_finding_aid_display -->
+            <datafield tag="856" ind1="4" ind2="2">
+              <subfield code="z">Finding aid</subfield>
+              <subfield code="u">http://library.temple.edu/finding_aids</subfield>
+            </datafield>
+          </record>
+        '}
+
+        it "does map to url_finding_aid_display(finding_aids)" do
+          expect(subject.map_record(record)).to eq(
+            "url_finding_aid_display" => [ { title: "Finding aid", url: "http://library.temple.edu/finding_aids" }.to_json ])
         end
       end
     end


### PR DESCRIPTION
- The new library website uses /finding_aids instead of /scrc.
- We need to have logic for both the old and new cases right now, so this adds an or statement to the extract_url_finding_aid method and the extract_url_more_links
- Also fixes a typo