### PR TITLE
BL-1101 Finding aids logic

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -264,7 +264,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             unless f["u"].nil?
               if f.indicator2 == "2" || NOT_FULL_TEXT.match(label) || !rec.fields("PRT").empty? || f["u"].include?(ARCHIVE_IT_LINKS)
-                unless (f["u"].match?(/http[s]*:\/\/library.temple.edu/) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
+                unless (f["u"].match?(/http[s]*:\/\/library.temple.edu/)) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -264,7 +264,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             unless f["u"].nil?
               if f.indicator2 == "2" || NOT_FULL_TEXT.match(label) || !rec.fields("PRT").empty? || f["u"].include?(ARCHIVE_IT_LINKS)
-                unless f["u"].include?("http://library.temple.edu") && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
+                unless (f["u"].include?("http://library.temple.edu") || f["u"].include?("https://library.temple.edu")) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end
@@ -279,7 +279,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             if f.indicator1 == "4" && f.indicator2 == "2"
               unless f["u"].nil?
-                if f["u"].include?("http://library.temple.edu") && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
+                if (f["u"].include?("http://library.temple.edu") || f["u"].include?("https://library.temple.edu")) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -264,7 +264,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             unless f["u"].nil?
               if f.indicator2 == "2" || NOT_FULL_TEXT.match(label) || !rec.fields("PRT").empty? || f["u"].include?(ARCHIVE_IT_LINKS)
-                unless (f["u"].include?("http://library.temple.edu") || f["u"].include?("https://library.temple.edu")) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
+                unless (f["u"].match?(/http[s]*:\/\/library.temple.edu/))  && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end
@@ -279,7 +279,7 @@ module Traject
             label = url_label(f["z"], f["3"], f["y"])
             if f.indicator1 == "4" && f.indicator2 == "2"
               unless f["u"].nil?
-                if (f["u"].include?("http://library.temple.edu") || f["u"].include?("https://library.temple.edu")) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
+                if (f["u"].match?(/http[s]*:\/\/library.temple.edu/)) && (f["u"].include?("scrc") || f["u"].include?("finding_aids"))
                   acc << { title: label, url: f["u"] }.to_json
                 end
               end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -931,7 +931,7 @@ RSpec.describe Traject::Macros::Custom do
         end
       end
 
-      context "856 field includes temple and scrc" do
+      context "856 field includes temple and scrc with http" do
         let(:record_text) { '
           <record>
             <!-- 11. Links with temple url and scrc map to url_finding_aid_display -->
@@ -945,6 +945,23 @@ RSpec.describe Traject::Macros::Custom do
         it "it does map to url_finding_aid_display(scrc)" do
           expect(subject.map_record(record)).to eq(
             "url_finding_aid_display" => [ { title: "Finding aid", url: "http://library.temple.edu/scrc" }.to_json ])
+        end
+      end
+
+      context "856 field includes temple and scrc with https" do
+        let(:record_text) { '
+          <record>
+            <!-- 11. Links with temple url and scrc map to url_finding_aid_display -->
+            <datafield tag="856" ind1="4" ind2="2">
+              <subfield code="z">Finding aid https</subfield>
+              <subfield code="u">https://library.temple.edu/scrc</subfield>
+            </datafield>
+          </record>
+        ' }
+
+        it "it does map to url_finding_aid_display(scrc)" do
+          expect(subject.map_record(record)).to eq(
+            "url_finding_aid_display" => [ { title: "Finding aid https", url: "https://library.temple.edu/scrc" }.to_json ])
         end
       end
 


### PR DESCRIPTION
- The original finding aids/more links logic was developed using http addresses.
- Since the library now uses https, we need to add that logic in.
- Some of the old records still have http, so we need to handle both instances.