### PR TITLE
BL-1049 Suppress empty records

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -490,17 +490,16 @@ module Traject
 
       def suppress_items
         lambda do |rec, acc, context|
+          full_text_link = rec.fields("856").select { |field| field["u"] }
           unassigned = rec.fields("ITM").select { |field| field["g"] == "UNASSIGNED" }
           lost = rec.fields("ITM").select { |field| field["u"] == "LOST_LOAN" }
           missing = rec.fields("ITM").select { |field| field["u"] == "MISSING" }
           technical = rec.fields("ITM").select { |field| field["u"] == "TECHNICAL" }
           unwanted_library = rec.fields("HLD").select { |field| field["b"] == "EMPTY" || field["c"] == "UNASSIGNED" }
 
-          if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty? || !unassigned.empty?)
-            acc.replace([true])
-          elsif rec.fields("HLD").length == 1 && !unwanted_library.empty?
-            acc.replace([true])
-          end
+          acc.replace([true]) if rec.fields("HLD").length == 0 && (rec.fields("PRT").length == 0 && full_text_link.empty?)
+          acc.replace([true]) if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty? || !unassigned.empty?)
+          acc.replace([true]) if rec.fields("HLD").length == 1 && !unwanted_library.empty?
 
           if acc == [true] && ENV["TRAJECT_FULL_REINDEX"] == "yes"
             context.skip!

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1231,6 +1231,18 @@ RSpec.describe Traject::Macros::Custom do
         expect(subject.map_record(records[6])).to eq({})
       end
     end
+
+    context "when there are no HLD, PRT, or 856['u'] fields" do
+      it "does suppress this file" do
+        expect(subject.map_record(records[7])).to eq("suppress_items_b" => [true])
+      end
+    end
+
+    context "when there are no HLD, PRT, but 856['u'] fields are present" do
+      it "doesn't suppress this file" do
+        expect(subject.map_record(records[8])).to eq({})
+      end
+    end
   end
 
   describe "full reindex #suppress_items" do

--- a/spec/fixtures/marc_files/lost_missing_technical.xml
+++ b/spec/fixtures/marc_files/lost_missing_technical.xml
@@ -66,6 +66,8 @@
 	<record>
 		<!-- 3. Multiple items with one lost -->
     <controlfield tag="001">3</controlfield>
+		<datafield ind1=" " ind2=" " tag="HLD">
+		</datafield>
 		<datafield ind1=" " ind2=" " tag="ITM">
 			<subfield code="r">22423620830003811</subfield>
 			<subfield code="b">0</subfield>
@@ -346,6 +348,8 @@
   <!-- 6. PR #1108 One unassigned -->
   <record xmlns="http://www.loc.gov/MARC21/slim">
     <controlfield tag="001">991026206569703811</controlfield>
+		<datafield ind1=" " ind2=" " tag="HLD">
+		</datafield>
     <datafield ind1=" " ind2=" " tag="ITM">
       <subfield code="r">22311821240003811</subfield>
       <subfield code="b">1</subfield>
@@ -373,4 +377,19 @@
       <subfield code="f">EMPTY</subfield>
     </datafield>
   </record>
+
+	<!-- 7. Empty HLD and PRT with no 856["u"] present -->
+  <record>
+    <controlfield tag="001">991014245629703811</controlfield>
+  </record>
+
+	<!-- 8. Empty HLD and PRT with 856["u"] present -->
+	<record>
+		<controlfield tag="001">991014245629703811</controlfield>
+		<datafield ind1="4" ind2="0" tag="856">
+			<subfield code="u">http://libproxy.temple.edu/login?url=http://lib.myilibrary.com/detail.asp?id=359867</subfield>
+			<subfield code="z">Connect to MyiLibrary resource.</subfield>
+		</datafield>
+	</record>
+
 </collection>


### PR DESCRIPTION
- Records should be suppressed if they have no HLD or PRT fields as long as there is also no 856["u"] present