### PR TITLE
BL-1056 Subject headings update

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -149,7 +149,8 @@ module Traject
       def translate_subject_field!(field)
         if field.tag == "650"
           field.subfields.map! { |sf|
-            sf.value = subject_translations(sf.value) if sf.code == "a"
+            trimmed_sf = sf.value.sub(/ *[ ,.\/;:] *\Z/, "")
+            sf.value = subject_translations(trimmed_sf) if sf.code == "a"
             sf
           }
         end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1081,23 +1081,48 @@ RSpec.describe Traject::Macros::Custom do
     context "when translatable subject is present in 650a" do
       it "translates subject" do
         record_text = <<-EOT
-<record xmlns="http://www.loc.gov/MARC21/slim">
-  <datafield ind1=" " ind2="0" tag="650">
-    <subfield code="a">Illegal aliens</subfield>
-    <subfield code="z">United States</subfield>
-    <subfield code="v">Pictorial works.</subfield>
-  </datafield>
-  <datafield ind1=" " ind2="0" tag="650">
-    <subfield code="a">Presidents' spouses</subfield>
-    <subfield code="z">United States</subfield>
-    <subfield code="v">Pictorial works.</subfield>
-  </datafield>
-</record>
-EOT
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Illegal aliens</subfield>
+            <subfield code="z">United States</subfield>
+            <subfield code="v">Pictorial works.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Presidents' spouses</subfield>
+            <subfield code="z">United States</subfield>
+            <subfield code="v">Pictorial works.</subfield>
+          </datafield>
+        </record>
+        EOT
+
         record = MARC::XMLReader.new(StringIO.new(record_text)).first
         expect(subject.map_record(record)["subject_display"]).to eq([
           "Undocumented immigrants — United States — Pictorial works",
           "Presidents' spouses — United States — Pictorial works",
+        ])
+      end
+    end
+
+    context "when translatable subject is present in 650a with punctuation" do
+      it "translates subject" do
+        record_text = <<-EOT
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Illegal aliens</subfield>
+            <subfield code="z">United States</subfield>
+            <subfield code="v">Pictorial works.</subfield>
+          </datafield>
+          <datafield ind1=" " ind2="0" tag="650">
+          <subfield code="a">Illegal aliens.</subfield>
+            <subfield code="x">Southern States </subfield>
+          </datafield>
+        </record>
+        EOT
+
+        record = MARC::XMLReader.new(StringIO.new(record_text)).first
+        expect(subject.map_record(record)["subject_display"]).to eq([
+          "Undocumented immigrants — United States — Pictorial works",
+          "Undocumented immigrants — Southern States",
         ])
       end
     end


### PR DESCRIPTION
- Our translation only worked for 650["a"] if there was no punctuation.  
- This trims punctuation first so that all necessary values are translated to the desired value