### PR TITLE
BL-1056 Subject headings

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -146,8 +146,9 @@ module Traject
         }
 
         translations.default_proc = proc { |hash, key|
-          if translations.key? key.gsub!(/\.$/, "")
-            hash[key]
+          key2 = key.gsub!(/\.$/, "")
+          if translations.key? key2
+            hash[key2]
           else
             subject
           end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -146,7 +146,7 @@ module Traject
         }
 
         translations.default_proc = proc { |hash, key|
-          key2 = key.gsub!(/\.$/, "")
+          key2 = key.gsub(/\.$/, "")
           if translations.key? key2
             hash[key2]
           else

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1126,6 +1126,24 @@ RSpec.describe Traject::Macros::Custom do
         ])
       end
     end
+
+    context "when a non-translatable subject is present in 650a with punctuation" do
+      it "keeps the punctuation" do
+        record_text = <<-EOT
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <datafield ind1=" " ind2="0" tag="650">
+            <subfield code="a">Test subject.</subfield>
+            <subfield code="z">United States</subfield>
+          </datafield>
+        </record>
+        EOT
+
+        record = MARC::XMLReader.new(StringIO.new(record_text)).first
+        subject.map_record(record)
+        expect(record.fields.first.value).to eq("Test subject.United States")
+      end
+    end
+
   end
 
   describe "#extract_genre_display" do


### PR DESCRIPTION
- We need to keep punctuation when a field is not translated.  
- This updates the method and adds a test