### PR TITLE
BL-1148 Suppress records when all items are lost/missing/etc.

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -543,8 +543,7 @@ module Traject
           }
 
           acc.replace([true]) if rec.fields("HLD").length == 0 && (rec.fields("PRT").length == 0 && full_text_link.empty?)
-          acc.replace([true]) if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty? || !unassigned.empty?)
-          acc.replace([true]) if rec.fields("ITM").length > 1 && u_subfields.all? { |f| f == "LOST_LOAN" || f == "MISSING" || f == "TECHNICAL" || f == "UNASSIGNED" }
+          acc.replace([true]) if rec.fields("ITM").length >= 1 && u_subfields.all? { |f| f == "LOST_LOAN" || f == "MISSING" || f == "TECHNICAL" || f == "UNASSIGNED" }
           acc.replace([true]) if rec.fields("HLD").length == 1 && !unwanted_library.empty?
 
           if acc == [true] && ENV["TRAJECT_FULL_REINDEX"] == "yes"

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -532,10 +532,6 @@ module Traject
       def suppress_items
         lambda do |rec, acc, context|
           full_text_link = rec.fields("856").select { |field| field["u"] }
-          unassigned = rec.fields("ITM").select { |field| field["g"] == "UNASSIGNED" }
-          lost = rec.fields("ITM").select { |field| field["u"] == "LOST_LOAN" }
-          missing = rec.fields("ITM").select { |field| field["u"] == "MISSING" }
-          technical = rec.fields("ITM").select { |field| field["u"] == "TECHNICAL" }
           unwanted_library = rec.fields("HLD").select { |field| field["b"] == "EMPTY" || field["c"] == "UNASSIGNED" }
           u_subfields = []
           rec.fields("ITM").select { |field|

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -537,9 +537,14 @@ module Traject
           missing = rec.fields("ITM").select { |field| field["u"] == "MISSING" }
           technical = rec.fields("ITM").select { |field| field["u"] == "TECHNICAL" }
           unwanted_library = rec.fields("HLD").select { |field| field["b"] == "EMPTY" || field["c"] == "UNASSIGNED" }
+          u_subfields = []
+          rec.fields("ITM").select { |field|
+            u_subfields << field["u"]
+          }
 
           acc.replace([true]) if rec.fields("HLD").length == 0 && (rec.fields("PRT").length == 0 && full_text_link.empty?)
           acc.replace([true]) if rec.fields("ITM").length == 1 && (!lost.empty? || !missing.empty? || !technical.empty? || !unassigned.empty?)
+          acc.replace([true]) if rec.fields("ITM").length > 1 && u_subfields.all? { |f| f == "LOST_LOAN" || f == "MISSING" || f == "TECHNICAL" || f == "UNASSIGNED" }
           acc.replace([true]) if rec.fields("HLD").length == 1 && !unwanted_library.empty?
 
           if acc == [true] && ENV["TRAJECT_FULL_REINDEX"] == "yes"

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1341,6 +1341,19 @@ EOT
         expect(subject.map_record(records[8])).to eq({})
       end
     end
+
+    context "when all fields are lost or missing" do
+      it "does suppress the file" do
+        expect(subject.map_record(records[9])).to eq("suppress_items_b" => [true])
+      end
+    end
+
+    context "when only some fields are lost or missing" do
+      it "doesn't suppress this file" do
+        expect(subject.map_record(records[10])).to eq({})
+      end
+    end
+
   end
 
   describe "full reindex #suppress_items" do

--- a/spec/fixtures/marc_files/lost_missing_technical.xml
+++ b/spec/fixtures/marc_files/lost_missing_technical.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
+<collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
 	<record>
 		<!-- 0. Only 1 lost item -->
     <controlfield tag="001">4</controlfield>
@@ -391,5 +391,87 @@
 			<subfield code="z">Connect to MyiLibrary resource.</subfield>
 		</datafield>
 	</record>
-
+	<record>
+		<!-- 9. All items lost or missing -->
+		<controlfield tag="001">4</controlfield>
+		<datafield ind1=" " ind2=" " tag="HLD">
+		</datafield>
+		<datafield ind1=" " ind2=" " tag="ITM">
+			<subfield code="r">22423620830003811</subfield>
+			<subfield code="b">0</subfield>
+			<subfield code="u">LOST_LOAN</subfield>
+			<subfield code="h">0</subfield>
+			<subfield code="g">stacks</subfield>
+			<subfield code="t">BOOK</subfield>
+			<subfield code="9">39074026623983</subfield>
+			<subfield code="e">stacks</subfield>
+			<subfield code="l">0</subfield>
+			<subfield code="8">23423620820003811</subfield>
+			<subfield code="j">0</subfield>
+			<subfield code="a">0</subfield>
+			<subfield code="q">2018-04-26 14:44:39</subfield>
+			<subfield code="i">LB1033 .Y95 2018</subfield>
+			<subfield code="d">MAIN</subfield>
+			<subfield code="f">MAIN</subfield>
+		</datafield>
+		<datafield ind1=" " ind2=" " tag="ITM">
+			<subfield code="r">22423620830003811</subfield>
+			<subfield code="b">0</subfield>
+			<subfield code="u">MISSING</subfield>
+			<subfield code="h">0</subfield>
+			<subfield code="g">stacks</subfield>
+			<subfield code="t">BOOK</subfield>
+			<subfield code="9">39074026623983</subfield>
+			<subfield code="e">stacks</subfield>
+			<subfield code="l">0</subfield>
+			<subfield code="8">23423620820003811</subfield>
+			<subfield code="j">0</subfield>
+			<subfield code="a">0</subfield>
+			<subfield code="q">2018-04-26 14:44:39</subfield>
+			<subfield code="i">LB1033 .Y95 2018</subfield>
+			<subfield code="d">MAIN</subfield>
+			<subfield code="f">MAIN</subfield>
+		</datafield>
+	</record>
+	<record>
+		<!-- 10. Some items lost or missing -->
+		<controlfield tag="001">4</controlfield>
+		<datafield ind1=" " ind2=" " tag="HLD">
+		</datafield>
+		<datafield ind1=" " ind2=" " tag="ITM">
+			<subfield code="r">22423620830003811</subfield>
+			<subfield code="b">0</subfield>
+			<subfield code="u">LOST_LOAN</subfield>
+			<subfield code="h">0</subfield>
+			<subfield code="g">stacks</subfield>
+			<subfield code="t">BOOK</subfield>
+			<subfield code="9">39074026623983</subfield>
+			<subfield code="e">stacks</subfield>
+			<subfield code="l">0</subfield>
+			<subfield code="8">23423620820003811</subfield>
+			<subfield code="j">0</subfield>
+			<subfield code="a">0</subfield>
+			<subfield code="q">2018-04-26 14:44:39</subfield>
+			<subfield code="i">LB1033 .Y95 2018</subfield>
+			<subfield code="d">MAIN</subfield>
+			<subfield code="f">MAIN</subfield>
+		</datafield>
+		<datafield ind1=" " ind2=" " tag="ITM">
+			<subfield code="r">22423620830003811</subfield>
+			<subfield code="b">0</subfield>
+			<subfield code="h">0</subfield>
+			<subfield code="g">stacks</subfield>
+			<subfield code="t">BOOK</subfield>
+			<subfield code="9">39074026623983</subfield>
+			<subfield code="e">stacks</subfield>
+			<subfield code="l">0</subfield>
+			<subfield code="8">23423620820003811</subfield>
+			<subfield code="j">0</subfield>
+			<subfield code="a">0</subfield>
+			<subfield code="q">2018-04-26 14:44:39</subfield>
+			<subfield code="i">LB1033 .Y95 2018</subfield>
+			<subfield code="d">MAIN</subfield>
+			<subfield code="f">MAIN</subfield>
+		</datafield>
+	</record>
 </collection>


### PR DESCRIPTION
- We are currently suppressing lost/missing items when there is only 1 item
- This updates the method to check whether all of item subfield["u"] are lost/missing and suppresses them