### PR TITLE
Add hathi_bib_key_display for relvant items

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -201,6 +201,7 @@ to_field "sudoc_display", extract_marc("086|0*|a")
 to_field "gpo_display", extract_marc("074a")
 to_field "oclc_number_display", extract_oclc_number
 to_field "alma_mms_display", extract_marc("001")
+to_field "hathi_trust_bib_key_display", lookup_hathi_bib_key
 
 # Preceding Entry fields
 to_field "continues_display", extract_marc("780|00|iabdghkmnopqrstuxyz3:780|02|iabdghkmnopqrstuxyz3", trim_punctuation: true)

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -569,6 +569,18 @@ module Traject
         end
       end
 
+      def lookup_hathi_bib_key
+        lambda do |rec, acc|
+          oclc_nums = []
+          extract_oclc_number.call(rec, oclc_nums)
+          oclc_nums.map do |oclc_num|
+            acc << `grep -o '^.*,#{oclc_num}$' lib/hathi_data/overlap.csv`.split(",").first
+          end
+
+          acc.uniq!
+        end
+      end
+
       def extract_item_info
         lambda do |rec, acc, context|
           holding_ids = rec.fields("HLD").map  { |field| field["8"] }.compact.uniq

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1471,6 +1471,52 @@ EOT
     end
   end
 
+  describe "#lookup_oclc_number" do
+    let(:path) { "oclc.xml" }
+
+    before do
+      subject.instance_eval do
+        to_field "hathi_bib_key_display", lookup_hathi_bib_key
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "when there is no 035 or 979 field" do
+      it "does not map record" do
+        expect(subject.map_record(records[0])).to eq({})
+      end
+    end
+
+    context "when the record has an oclc number but it is not in the hathi overlap file" do
+      it "does not map record" do
+        expect(subject.map_record(records[1])).to eq({})
+      end
+    end
+
+    context "when the record has an oclc number and it is in the hathi overlap file" do
+      it "does not map record" do
+        expect(subject.map_record(records[10])).to eq("hathi_bib_key_display" => ["102691365"])
+      end
+    end
+
+    context "when the record has multiple oclc number and one is in the hathi overlap file" do
+      it "does not map record" do
+        expect(subject.map_record(records[11])).to eq("hathi_bib_key_display" => ["102691365"])
+      end
+    end
+
+    context "when the record has multiple oclc number and more than one is in the hathi overlap file" do
+      it "does not map record" do
+        expect(subject.map_record(records[12])["hathi_bib_key_display"]).to include("102691365", "102691351")
+      end
+    end
+  end
+
+
+
+
   describe "#extract_work_access_point" do
 
     before do

--- a/spec/fixtures/marc_files/oclc.xml
+++ b/spec/fixtures/marc_files/oclc.xml
@@ -64,4 +64,28 @@
       <subfield code="a">ocm03885910</subfield>
     </datafield>
   </record>
+  <record>
+  <!-- 10. number matches a record in hathi overap file -->
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocm010498545</subfield>
+    </datafield>
+  </record>
+  <record>
+  <!-- 11. multiple oclc numbers, one number matches a record in hathi overap file -->
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)938995310</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocm010498545</subfield>
+    </datafield>
+  </record>
+  <record>
+  <!-- 12. multiple oclc numbers, multiple match a record in hathi overap file -->
+    <datafield ind1=" " ind2=" " tag="035">
+      <subfield code="a">(OCoLC)1474971</subfield>
+    </datafield>
+    <datafield ind1=" " ind2=" " tag="979">
+      <subfield code="a">ocn10498545</subfield>
+    </datafield>
+  </record>
 </collection>


### PR DESCRIPTION
Adds a csv file in `lib/hathi_data_overlap.csv` that contains oclc
number and Hathi Trust bib_key for physical items in the Temple
collection that have been digitized by Hathi and are available under the
temporary emergency access program.

This change causes traject to search (grep) the overlap.csv file for the
records oclc number. If it returns nothing, no record is created. If it
matches, it returns a string with "bib_key,oclc_num".

This will slow down the indexing process as grepping a 12MB file takes
~.35 seconds, which is substantally slower than a usual traject processing task. We could optimize if needed, but I wanted to get a first pass in for other to look at.

I've written up a rough sketch of the[ process for creating the overlap csv ](https://github.com/bibliotechy/bibliotechy.github.com/wiki/Hathi-writeup).