### PR TITLE
Make supression logic a little safer.

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -535,7 +535,7 @@ module Traject
       def suppress_items
         lambda do |rec, acc, context|
           full_text_link = rec.fields("856").select { |field| field["u"] }
-          purchase_order_item = rec.fields("902").select { |field| field["a"].match?(/EBC-POD/) }
+          purchase_order_item = rec.fields("902").select { |field| field["a"].match?(/EBC-POD/) if field["a"] }
           unwanted_library = rec.fields("HLD").select { |field| field["b"] == "EMPTY" || field["c"] == "UNASSIGNED" }
           u_subfields = []
           rec.fields("ITM").select { |field|

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1400,6 +1400,11 @@ EOT
       end
     end
 
+    context "has a malformed 902 field" do
+      it "doesn't raise an error" do
+        expect { subject.map_record(records[14]) }.not_to raise_error
+      end
+    end
   end
 
   describe "full reindex #suppress_items" do

--- a/spec/fixtures/marc_files/lost_missing_technical.xml
+++ b/spec/fixtures/marc_files/lost_missing_technical.xml
@@ -492,4 +492,11 @@
 		<subfield code="a">test</subfield>
 	</datafield>
 </record>
+<!-- 14. BAAAD Record-->
+<record>
+  <controlfield tag="001">991037333029003811</controlfield>
+  <datafield tag="902" ind1=" " ind2=" ">
+    <subfield code="A">SP: Academic Video Online 20191115</subfield>
+  </datafield>
+</record>
 </collection>


### PR DESCRIPTION
We errored out in production when a MARC record contained a malformed 902. This makes that method a little safer.