### PR TITLE
Fix harvest fails when mms_id not exactly 18 digits long.

### DIFF
--- a/lib/cob_index/nokogiri_indexer.rb
+++ b/lib/cob_index/nokogiri_indexer.rb
@@ -29,7 +29,7 @@ module CobIndex
     def get_id(record)
       do_with_error_log("Failed to get id for record", record) do
         record.at_xpath("//oai:record/oai:header/oai:identifier", default_namespaces)
-          .text().scan(/[0-9]+{18}/).first
+          .text().scan(/[0-9]+{8}$/).first
       end
     end
 


### PR DESCRIPTION
The get_id method assumed all mms_ids are 18 digits long and if not was
returning nil for the id.