### PR TITLE
BL-1175 Normalize LCCN numbers

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -419,7 +419,6 @@ module Traject
           acc.map! { |x|
             formatted_x = x.gsub("#", " ")
             StdNum::LCCN.normalize(formatted_x) }
-          acc.flatten!
           acc.uniq!
         end
       end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -416,9 +416,9 @@ module Traject
 
       def normalize_lccn
         Proc.new do |rec, acc|
-          orig = acc.dup
-          acc.map! { |x| StdNum::LCCN.normalize(x) }
-          acc << orig
+          acc.map! { |x|
+            formatted_x = x.gsub("#", " ")
+            StdNum::LCCN.normalize(formatted_x) }
           acc.flatten!
           acc.uniq!
         end

--- a/spec/cob_index/macros/normalize_lccn_spec.rb
+++ b/spec/cob_index/macros/normalize_lccn_spec.rb
@@ -48,5 +48,34 @@ RSpec.describe Traject::Macros::Custom do
         expect(subject.map_record(record)).to eq("lccn_display" => [ "87014950" ])
       end
     end
+
+    context "LCCN includes a # symbol" do
+      let(:record_text) { '
+        <record>
+        <datafield ind1=" " ind2=" " tag="010">
+        <subfield code="a">sn#00061556</subfield>
+        </datafield>
+        </record>
+      ' }
+
+      it "removes the # symbol and empty spaces" do
+        expect(subject.map_record(record)).to eq("lccn_display" => [ "sn00061556" ])
+      end
+    end
+
+    context "LCCN includes a / symbol" do
+      let(:record_text) { '
+        <record>
+        <datafield ind1=" " ind2=" " tag="010">
+        <subfield code="a">25004346#//r822</subfield>
+        </datafield>
+        </record>
+      ' }
+
+      it "removes the / and all text to the right of it" do
+        expect(subject.map_record(record)).to eq("lccn_display" => [ "25004346" ])
+      end
+    end
+
   end
 end


### PR DESCRIPTION
- Updates the normalize_lccn method to only return the normalized lccn numbers
- Adds tests 
- Substitutes an empty space for the # symbol because the normalizer doesn't handle that edge case