### PR TITLE
Delete suppressed documents from the solr catatlog

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -234,3 +234,7 @@ to_field "purchase_order", extract_purchase_order
 # a=create date, b=update date, c=Suppress from publishing, d=Originating system, e=Originating system ID, f=Originating system version
 to_field "record_creation_date", extract_marc("ADMa"), default("2001-01-01 01:01:01")
 to_field "record_update_date", extract_update_date, default("2002-02-02 02:02:02")
+
+after_processing do
+  writer.delete_batch(DELETES)
+end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -553,6 +553,7 @@ module Traject
           if acc == [true] && ENV["TRAJECT_FULL_REINDEX"] == "yes"
             context.skip!
           elsif acc == [true]
+            context.skip!
             DELETES << context
           end
         end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -531,6 +531,9 @@ module Traject
         end
       end
 
+      # DELETES needs to be a global so we can access from indexer_config.
+      DELETES = Concurrent::Set.new
+
       def suppress_items
         lambda do |rec, acc, context|
           full_text_link = rec.fields("856").select { |field| field["u"] }
@@ -549,6 +552,8 @@ module Traject
 
           if acc == [true] && ENV["TRAJECT_FULL_REINDEX"] == "yes"
             context.skip!
+          elsif acc == [true]
+            DELETES << context
           end
         end
       end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1506,7 +1506,7 @@ EOT
 
     context "when a single item is lost" do
       it "does not maps lost record" do
-        expect(@indexer.process_record(records[0]).skip?).to eq(false)
+        expect(@indexer.process_record(records[0]).skip?).to eq(true)
         expect(DELETES).not_to be_empty
       end
     end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1486,6 +1486,33 @@ EOT
     end
   end
 
+  describe "Non full reindex #suppress_items" do
+    let(:path) { "lost_missing_technical.xml" }
+
+    before do
+      stub_const("ENV", ENV.to_hash.merge("TRAJECT_FULL_REINDEX" => "no"))
+
+      @writer = Traject::ArrayWriter.new
+      @indexer = Traject::Indexer.new(writer: @writer) do
+        to_field "suppress_items_b", suppress_items
+      end
+
+      subject.instance_eval do
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "when a single item is lost" do
+      it "does not maps lost record" do
+        expect(@indexer.process_record(records[0]).skip?).to eq(false)
+        expect(DELETES).not_to be_empty
+      end
+    end
+  end
+
+
   describe "#extract_oclc_number" do
     let(:path) { "oclc.xml" }
 


### PR DESCRIPTION
When not in FULL_REINDEX context we do not skip items for ingest, instead we
flip a suppression field on the Solr document that is about to be indexed and
then we rely on filtering that document using Solr configuration at query time.

We do this because merely skipping index would not account for the documents already
present in the Solr database and we have always assumed that the task of
deleting the suppressed items would be unduly complicated.

Since we have implemented our own delete feature for cob_index (for another
issue) we can easily leverage that new feature to simply delete documents that
would otherwise be suppressed.