### PR TITLE
Add back required arg_name for commands.

### DIFF
--- a/exe/cob_index
+++ b/exe/cob_index
@@ -15,6 +15,7 @@ class App
   arguments :strict
 
   desc "Ingest files into solr endpoint using tul_cob traject config"
+  arg_name "filepath/URL"
   command :ingest do |c|
     c.desc "Commit docs after ingest process closes."
     c.switch ["commit"], default_value: false
@@ -38,6 +39,7 @@ class App
   end
 
   desc "Delete documents from solr endpoint"
+  arg_name "filepath/URL"
   command :delete do |c|
     c.desc "Commit docs after delete process closes."
     c.switch ["commit"], default_value: false
@@ -54,6 +56,7 @@ class App
   end
 
   desc "Harvest documents from various endpoints."
+  arg_name "filepath/OAI-endpoint"
   command :harvest do |c|
     c.desc "Type of harvest to perform. Defaults to Alma Electrnic harvest."
     c.flag ["type"], default_value: "alma-electronic"

--- a/exe/cob_index
+++ b/exe/cob_index
@@ -33,7 +33,8 @@ class App
   desc "Send commit command to the Solr instance."
   command :commit do |c|
     c.desc "Commit docs after ingest process closes."
-    c.desc "Send commit command to the Solr instance." do
+    c.desc "Send commit command to the Solr instance."
+    c.action do |global_options, options, args|
       CobIndex::CLI.commit
     end
   end


### PR DESCRIPTION
* Without arg_name command fails if it requires an argument