### PR TITLE
BL-1165-lc-call-number-sort

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -101,6 +101,7 @@ to_field "creator_vern_display", extract_creator_vern
 to_field "contributor_vern_display", extract_contributor_vern
 
 to_field "author_sort", extract_marc("100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt", trim_punctuation: true, first: true)
+to_field "lc_call_number_sort", extract_lc_call_number_sort
 
 # Publication fields
 # For the imprint, make sure to take RDA-style 264, second indicator = 1


### PR DESCRIPTION
Processes lc call numbers into codes that will sort correctly in solr. 

Note that the real tests are in tul_cob/indices_spec.rb. Perhaps it would make sense at some point to add integration tests that use solr?