### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.7
+  - 2.7.2
 services:
   - docker
 


### PR DESCRIPTION
Travis is trying to use ruby 2.7.1 and not finding it since we are using 2.7.2.