### PR TITLE
BL-1319 Remove extra genre fields

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -164,10 +164,7 @@ to_field "subject_topic_facet", extract_subject_topic_facet
 to_field "subject_era_facet", extract_marc("648a:650y:651y:654y:655y:690y:647y", trim_punctuation: true)
 to_field "subject_region_facet", marc_geo_facet
 to_field "genre_facet", extract_genre
-to_field "genre_display", extract_genre_display
 to_field "genre_t", extract_genre_display
-# genre_full_facet is an invisible field that is used to generate the direct links on individual record pages
-to_field "genre_full_facet", extract_genre_display
 
 to_field "subject_t", extract_marc_with_flank(%W(
   600#{A_TO_U}


### PR DESCRIPTION
- We are indexing the same genre mapping for three different fields
- This removes the _display and _facet fields, but keeps the _t field so that we get the correct solr configurations