### PR TITLE
Fix donor name typo

### DIFF
--- a/lib/translation_maps/donor_info.yaml
+++ b/lib/translation_maps/donor_info.yaml
@@ -234,7 +234,7 @@
 "991037344974403811": Kalman, Arnold I., Esq.
 "991037394107003811": Lang, Carol and Richard
 "991037429726703811": Walsh, Peggy and Tim
-"991037327690103811": Lucia, Joseph F. and Maria Gandolfo
+"991037327690103811": Lucia, Joseph P. and Maria Gandolfo
 "991037394104203811": Zimmer, William J., Jr.
 "991037756271803811": Smutko, Charlotte and John
 "991037768696603811": Averill, James H., Jr. and Janet


### PR DESCRIPTION
- Fix donor name typo

This is not a rush, but can be incorporated into the next full reindex.