### PR TITLE
BL-255: Remove some corporate names from creator_facet values.

### DIFF
--- a/lib/cob_index.rb
+++ b/lib/cob_index.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-require "cob_index/version"
-require "cob_index/dot_properties"
-require "cob_index/nokogiri_indexer"
 require "traject"
 require "alma/electronic/batch_utils"
 require "logger"
 
 
-
 module CobIndex
+  autoload :Macros, "cob_index/macros"
+  autoload :DefaultConfig, "cob_index/default_config"
+  autoload :DotProperties, "cob_index/dot_properties"
+  autoload :Version, "cob_index/version"
+  autoload :NokogiriIndexer, "cob_index/nokogiri_indexer"
+
   module CLI
     def self.ingest(commit: false, marc_xml: "")
       indexer = Traject::Indexer::MarcIndexer.new("solr_writer.commit_on_close": commit)

--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -22,7 +22,7 @@ extend Traject::Macros::MarcFormats
 require "unicode_normalize/normalize.rb"
 require "cob_index/macros/custom"
 extend Traject::Macros::Custom
-require "cob_index/default_config"
+extend CobIndex::Macros::Transformations
 
 settings(&CobIndex::DefaultConfig.indexer_settings)
 
@@ -83,7 +83,20 @@ to_field "title_sort", extract_marc("245abcfgknps", alternate_script: false, fir
 
 # Creator/contributor fields
 to_field "creator_t", extract_marc_with_flank("245c:100abcdejlmnopqrtu:110abcdelmnopt:111acdejlnopt:700abcdejqu:710abcde:711acdej", trim_punctuation: true)
-to_field "creator_facet", extract_marc("100abcdq:110abcd:111ancdj:700abcdq:710abcd:711ancdj", trim_punctuation: true)
+to_field "creator_facet", extract_marc("100abcdq:110abcd:111ancdj:700abcdq:710abcd:711ancdj", trim_punctuation: true), filter_values([
+  "Adam Matthew Digita",
+  "Adam Matthew Digital (Firm)",
+  "Alexander Street Press",
+  "Books24x7, Inc",
+  "EBSCO Publishing (Firm)",
+  "Ebook Central",
+  "Infobase",
+  "MyiLibrary",
+  "ProQuest (Firm)",
+  "ScienceDirect (Online service)",
+  "SpringerLink (Online service)",
+  "e-libro, Corp",
+])
 to_field "creator_display", extract_creator
 to_field "contributor_display", extract_contributor
 to_field "creator_vern_display", extract_creator_vern

--- a/lib/cob_index/macros.rb
+++ b/lib/cob_index/macros.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module CobIndex::Macros
+  autoload :Transformations, "cob_index/macros/transformations"
+end

--- a/lib/cob_index/macros/transformations.rb
+++ b/lib/cob_index/macros/transformations.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CobIndex::Macros::Transformations
+  def filter_values(list)
+    -> (value, acc) {
+      acc.select! do |v|
+        !list.include?(v)
+      end
+    }
+  end
+end

--- a/spec/cob_index/macros/transformations_spec.rb
+++ b/spec/cob_index/macros/transformations_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "rspec"
+require "cob_index/macros/transformations"
+require "cob_index/macros/marc_format_classifier"
+require "cob_index/macros/custom"
+require "cob_index/macros"
+
+require "traject/indexer"
+require "marc/record"
+
+include Traject::Macros::MarcFormats
+
+include Traject::Macros::Custom
+
+RSpec.describe CobIndex::Macros::Transformations do
+  let(:test_class) do
+    Class.new(Traject::Indexer)
+  end
+
+  let(:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
+
+  subject { test_class.new }
+
+  describe "#filter_values" do
+    before do
+      stub_const("ENV", ENV.to_hash.merge("SOLR_DISABLE_UPDATE_DATE_CHECK" => "false"))
+      subject.instance_eval do
+
+        extend Traject::Macros::Marc21
+        extend Traject::Macros::MarcFormats
+        extend CobIndex::Macros::Transformations
+        to_field "creator_facet", extract_marc("100abcdq:110abcd:111ancdj:700abcdq:710abcd:711ancdj", trim_punctuation: true), filter_values([
+          "FOO",
+          "Bizz (Buzz)"]);
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "No creators" do
+      let(:record_text) { "
+        <record>
+        </record>
+      "}
+
+      it "does not extract any creator" do
+        expect(subject.map_record(record)).to eq({})
+      end
+    end
+
+    context "Creator but none to filter" do
+      let(:record_text) { '
+        <record>
+          <datafield ind1=" " ind2=" " tag="100">
+            <subfield code="a">David Kinzer</subfield>
+          </datafield>
+        </record>
+      '}
+
+      it "extracts the creator" do
+        expect(subject.map_record(record)).to eq({
+          "creator_facet" => ["David Kinzer"],
+        })
+      end
+    end
+
+    context "Creator and stuff we don't want" do
+      let(:record_text) { '
+        <record>
+          <datafield ind1=" " ind2=" " tag="100">
+            <subfield code="a">David Kinzer</subfield>
+          </datafield>
+          <datafield ind1=" " ind2=" " tag="100">
+            <subfield code="a">FOO</subfield>
+          </datafield>
+        </record>
+      '}
+
+      it "extracts the creator" do
+        expect(subject.map_record(record)).to eq({
+          "creator_facet" => ["David Kinzer"],
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Adds new filter_stop_words macro that removes list of supplied values
from the final accumulation of field values.
* Updates field creator_facet indexing definition to add a list of
values to filter.
* Adds test for new macro;
* A little cleanup in order to add macro (plus setup for future
cleanup).