### PR TITLE
BL-300: Fix broken sorts for electronic resources.

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -337,7 +337,7 @@ module CobIndex::Macros::Custom
           # Then descending range (large year span comes first).
           # Then order by ascending title.
           # Then order by ascending subtitle.
-          [ 1.0/year_end, 1.0/range, title, subtitle]
+          [ 1.0 / year_end, 1.0 / range, title, subtitle]
         }
       rescue
         logger.error("Failed `sort_electronic_resource!` on sorting #{rec}")

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -321,7 +321,6 @@ module CobIndex::Macros::Custom
   # In the cases where there is multiple coverage statements with overlapping ranges, order by the end date.
   # When there is no end date (ex. Available from ####),  list at top and order by start date, listing those with widest coverage first.
   def sort_electronic_resource!
-    require "pry"
     lambda do |rec, acc, context|
       begin
         acc.sort_by! { |r|


### PR DESCRIPTION
* Does not assume "reverse" order when sorting breaks.
* Adds correct sorting criteria.
* Tests that sorting works for specified criteria.