### PR TITLE
BL-300 Sorting electronic resources

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -331,9 +331,10 @@ module CobIndex::Macros::Custom
                       /Available from (\d{4})?/.match(subfields["coverage_statement"]) ||
                       []
 
-          year_start = (available[1].last(4) || 1).to_i
-          just_year = available[2].gsub("/", "").last(4) unless available[2].nil?
-          year_end = (just_year || 9999).to_i
+          just_start_year = available[1].last(4) unless available[1].nil?
+          year_start = (just_start_year || 1).to_i
+          just_end_year = available[2].last(4) unless available[2].nil?
+          year_end = (just_end_year || 9999).to_i
           range = year_end - year_start
           collection_name = subfields["collection_name"].to_s
 

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -331,18 +331,18 @@ module CobIndex::Macros::Custom
                       /Available from (\d{4})?/.match(subfields["coverage_statement"]) ||
                       []
 
-          just_start_year = available[1].last(4) unless available[1].nil?
-          year_start = (just_start_year || 1).to_i
-          just_end_year = available[2].last(4) unless available[2].nil?
-          year_end = (just_end_year || 9999).to_i
-          range = year_end - year_start
+          start_year = available[1].last(4) unless available[1].nil?
+          start_year_sort = (start_year || 1).to_i
+          end_year = available[2].last(4) unless available[2].nil?
+          end_year_sort = (end_year || 9999).to_i
+          range = end_year_sort - start_year_sort
           collection_name = subfields["collection_name"].to_s
 
           # Order by year_end descending.
           # Then descending range (large year span comes first).
           # Then order by ascending title.
           # Then order by ascending subtitle.
-          [ 1.0 / year_end, 1.0 / range, collection_name ]
+          [ 1.0 / end_year_sort, 1.0 / range, collection_name ]
         }
       rescue
         logger.error("Failed `sort_electronic_resource!` on sorting #{rec}")

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -286,8 +286,8 @@ module CobIndex::Macros::Custom
           portfolio_id: f["a"],
           collection_id: f["i"],
           service_id: f["j"],
-          title: f["c"],
-          subtitle: f["g"],
+          collection_name: f["c"],
+          coverage_statement: f["g"],
           public_note: f["f"],
           availability: f["9"] }
           .delete_if { |k, v| v.blank? }
@@ -325,18 +325,23 @@ module CobIndex::Macros::Custom
       begin
         acc.sort_by! { |r|
           subfields = JSON.parse(r)
-          available = /Available from (\d{4})( until (\d{4}))?/.match(subfields["availability"]) || []
-          year_start = (available[1] || 1).to_i
-          year_end = (available[3] || 9999).to_i
+          available = /Available from (\d{2}\/\d{2}\/\d{4}) until (\d{2}\/\d{2}\/\d{4})?/.match(subfields["coverage_statement"]) ||
+                      /Available from (\d{2}\/\d{2}\/\d{4}).?/.match(subfields["coverage_statement"]) ||
+                      /Available from (\d{4}) until (\d{4})?/.match(subfields["coverage_statement"]) ||
+                      /Available from (\d{4})?/.match(subfields["coverage_statement"]) ||
+                      []
+
+          year_start = (available[1].last(4) || 1).to_i
+          just_year = available[2].gsub("/", "").last(4) unless available[2].nil?
+          year_end = (just_year || 9999).to_i
           range = year_end - year_start
-          title = subfields["title"].to_s
-          subtitle = subfields["subtitle"].to_s
+          collection_name = subfields["collection_name"].to_s
 
           # Order by year_end descending.
           # Then descending range (large year span comes first).
           # Then order by ascending title.
           # Then order by ascending subtitle.
-          [ 1.0 / year_end, 1.0 / range, title, subtitle]
+          [ 1.0 / year_end, 1.0 / range, collection_name ]
         }
       rescue
         logger.error("Failed `sort_electronic_resource!` on sorting #{rec}")

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -1172,13 +1172,11 @@ RSpec.describe CobIndex::Macros::Custom do
             <!-- 2. Only multiple PRT field  -->
             <datafield tag="PRT" ind1=" " ind2=" ">
               <subfield code="c">foo</subfield>
-              <subfield code="g">foo</subfield>
-              <subfield code="9">Available from 1973 until 2020</subfield>
+              <subfield code="g">Available from 1973 until 2020</subfield>
             </datafield>
             <datafield tag="PRT" ind1=" " ind2=" ">
               <subfield code="c">foo</subfield>
-              <subfield code="g">zoo</subfield>
-              <subfield code="9">Available from 1973 until 2021</subfield>
+              <subfield code="g">Available from 1973 until 2021</subfield>
             </datafield>
           </record>
         ' }
@@ -1186,8 +1184,8 @@ RSpec.describe CobIndex::Macros::Custom do
         it "uses the end date to break the sorting tie" do
           expect(subject.map_record(record)).to eq(
             "url_more_links_display" => [
-                { title: "foo", subtitle: "zoo", availability: "Available from 1973 until 2021" }.to_json,
-                { title: "foo", subtitle: "foo", availability: "Available from 1973 until 2020" }.to_json,
+                { collection_name: "foo", coverage_statement: "Available from 1973 until 2021" }.to_json,
+                { collection_name: "foo", coverage_statement: "Available from 1973 until 2020" }.to_json,
             ]
           )
         end
@@ -1198,13 +1196,11 @@ RSpec.describe CobIndex::Macros::Custom do
             <!-- 2. Only multiple PRT field  -->
             <datafield tag="PRT" ind1=" " ind2=" ">
               <subfield code="c">foo</subfield>
-              <subfield code="g">foo</subfield>
-              <subfield code="9">Available from 1973 until 2020</subfield>
+              <subfield code="g">Available from 1973 until 2020</subfield>
             </datafield>
             <datafield tag="PRT" ind1=" " ind2=" ">
               <subfield code="c">foo</subfield>
-              <subfield code="g">bar</subfield>
-              <subfield code="9">Available from 1972 until 2020</subfield>
+              <subfield code="g">Available from 1972 until 2020</subfield>
             </datafield>
           </record>
         ' }
@@ -1212,35 +1208,8 @@ RSpec.describe CobIndex::Macros::Custom do
         it "uses the date range size to break the sorting tie" do
           expect(subject.map_record(record)).to eq(
             "url_more_links_display" => [
-                { title: "foo", subtitle: "bar", availability: "Available from 1972 until 2020" }.to_json,
-                { title: "foo", subtitle: "foo", availability: "Available from 1973 until 2020" }.to_json,
-            ]
-          )
-        end
-      end
-
-      context "multiple PRT with same date range and title" do
-        let(:record_text) { '
-          <record>
-            <!-- 2. Only multiple PRT field  -->
-            <datafield tag="PRT" ind1=" " ind2=" ">
-              <subfield code="c">foo</subfield>
-              <subfield code="g">foo</subfield>
-              <subfield code="9">Available</subfield>
-            </datafield>
-            <datafield tag="PRT" ind1=" " ind2=" ">
-              <subfield code="c">foo</subfield>
-              <subfield code="g">bar</subfield>
-              <subfield code="9">Not Available</subfield>
-            </datafield>
-          </record>
-        ' }
-
-        it "uses the subtile to break the sorting tie" do
-          expect(subject.map_record(record)).to eq(
-            "url_more_links_display" => [
-                { title: "foo", subtitle: "bar", availability: "Not Available" }.to_json,
-                { title: "foo", subtitle: "foo", availability: "Available" }.to_json,
+                { collection_name: "foo", coverage_statement: "Available from 1972 until 2020" }.to_json,
+                { collection_name: "foo", coverage_statement: "Available from 1973 until 2020" }.to_json,
             ]
           )
         end
@@ -1252,13 +1221,11 @@ RSpec.describe CobIndex::Macros::Custom do
             <!-- 2. Only multiple PRT field  -->
             <datafield tag="PRT" ind1=" " ind2=" ">
               <subfield code="c">foo</subfield>
-              <subfield code="g">foo</subfield>
-              <subfield code="9">Available</subfield>
+              <subfield code="g">Available from 1973 until 2020</subfield>
             </datafield>
             <datafield tag="PRT" ind1=" " ind2=" ">
               <subfield code="c">bar</subfield>
-              <subfield code="g">foo</subfield>
-              <subfield code="9">Not Available</subfield>
+              <subfield code="g">Available from 1973 until 2020</subfield>
             </datafield>
           </record>
         ' }
@@ -1266,8 +1233,8 @@ RSpec.describe CobIndex::Macros::Custom do
         it "uses the title to break the sorting tie" do
           expect(subject.map_record(record)).to eq(
             "url_more_links_display" => [
-                { title: "bar", subtitle: "foo", availability: "Not Available" }.to_json,
-                { title: "foo", subtitle: "foo", availability: "Available" }.to_json,
+                { collection_name: "bar", coverage_statement: "Available from 1973 until 2020" }.to_json,
+                { collection_name: "foo", coverage_statement: "Available from 1973 until 2020" }.to_json,
             ]
           )
         end


### PR DESCRIPTION
- Updates the names of the electronic resource subfields to better reflect what they are
- Refactors code to get dates from the coverage_statement instead of the availability field