### PR TITLE
BL-1701 Adds new fields related to title_statement updates

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -41,12 +41,12 @@ to_field "lc_inner_facet", extract_lc_inner_facet
 # Title fields
 # Used on the full record page
 to_field "title_statement_display", extract_title_statement
-to_field "title_with_subtitle_display", extract_title_statement
+to_field "title_with_subtitle_display", extract_title_and_subtitle
 to_field "responsibility_display", extract_marc("245c")
 
 # Used in the catalog search results display
 to_field "title_truncated_display", extract_title_statement, &truncate(300)
-to_field "title_with_subtitle_truncated_display", extract_title_statement, &truncate(300)
+to_field "title_with_subtitle_truncated_display", extract_title_and_subtitle, &truncate(300)
 to_field "responsibility_truncated_display", extract_marc("245c"), &truncate(300)
 to_field "title_statement_vern_display", extract_marc("245abcfgknps", alternate_script: :only)
 to_field "title_with_subtitle_vern_display", extract_marc("245abfgknps", alternate_script: :only)

--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -41,14 +41,20 @@ to_field "lc_inner_facet", extract_lc_inner_facet
 # Title fields
 # Used on the full record page
 to_field "title_statement_display", extract_title_statement
+to_field "title_with_subtitle_display", extract_title_statement
+to_field "responsibility_display", extract_marc("245c")
+
 # Used in the catalog search results display
 to_field "title_truncated_display", extract_title_statement, &truncate(300)
+to_field "title_with_subtitle_truncated_display", extract_title_statement, &truncate(300)
+to_field "responsibility_truncated_display", extract_marc("245c"), &truncate(300)
 to_field "title_statement_vern_display", extract_marc("245abcfgknps", alternate_script: :only)
+to_field "title_with_subtitle_vern_display", extract_marc("245abfgknps", alternate_script: :only)
+to_field "responsibility_vern_display", extract_marc("245c", alternate_script: :only)
 to_field "title_uniform_display", extract_uniform_title
 to_field "title_uniform_vern_display", extract_marc("130adfklmnoprs:240adfklmnoprs:730ail", alternate_script: :only)
 to_field "title_addl_display", extract_additional_title
 to_field "title_addl_vern_display", extract_marc("210ab:246abfgnp:247abcdefgnp:740anp", alternate_script: :only)
-
 to_field "title_t", extract_marc("245a"), wrap_begin_end
 to_field "subtitle_t", extract_marc("245b"), wrap_begin_end
 to_field "title_statement_t", extract_marc("245abfgknps"), wrap_begin_end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -40,7 +40,7 @@ module CobIndex::Macros::Custom
 
       Traject::MarcExtractor.cached("245abfgknps", alternate_script: false).collect_matching_lines(rec) do |field, spec, extractor|
         title = extractor.collect_subfields(field, spec).find { |t| t.present? }
-       
+
         if field["c"].present?
           title = title&.chomp("/")&.rstrip
         end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -37,14 +37,12 @@ module CobIndex::Macros::Custom
   def extract_title_statement
     lambda do |rec, acc|
       titles = []
-      slash = "/"
 
-      Traject::MarcExtractor.cached("245abcfgknps", alternate_script: false).collect_matching_lines(rec) do |field, spec, extractor|
+      Traject::MarcExtractor.cached("245abfgknps", alternate_script: false).collect_matching_lines(rec) do |field, spec, extractor|
         title = extractor.collect_subfields(field, spec).find { |t| t.present? }
-        # Use 245c when 245h is present.
-        if field["h"].present? && field["c"].present?
-          title = title&.gsub(" #{field['c']}", " #{slash} #{field['c']}")
-          title = title&.gsub("/ /", "/")
+       
+        if field["c"].present?
+          title = title&.chomp("/")&.rstrip
         end
 
         titles << title unless title.blank?

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe CobIndex::Macros::Custom do
 
     before(:each) do
       subject.instance_eval do
-        to_field "title_statement_display", extract_title_statement
+        to_field "title_with_subtitle_display", extract_title_statement
 
         settings do
           provide "marc_source.type", "xml"
@@ -145,30 +145,23 @@ RSpec.describe CobIndex::Macros::Custom do
       end
     end
 
-    context "245 field incudes subfield h" do
-      it "adds a / before subfield c" do
-        expected = { "title_statement_display" => ["Die dritte generation / produziert von der Tango-Film Berlin ; zusammen mit der Pro-Ject Film-Produktion im Filmverlag der Autoren ; musik, Peer Raben ; ausstattung, Raùl Gimenez ; schnitt, Juliane Lorenz ; ein film von Rainer Werner Fassbinder."] }
+    context "245 field with subfield a" do
+      it "returns title and subtitle" do
+        expected = { "title_with_subtitle_display" => ["Die dritte generation" ] }
         expect(subject.map_record(records[0])).to eq(expected)
       end
     end
 
-    context "245 field does NOT incude subfield h" do
-      it "does not add a / before subfield c" do
-        expected = { "title_statement_display" => ["Printed circuits handbook."] }
-        expect(subject.map_record(records[1])).to eq(expected)
-      end
-    end
-
-    context "245 field has a slash in multiple fields" do
-      it "does not display double slashes" do
-        expected = { "title_statement_display" => ["Yaju no seishun Youth of the beast / a Janus Films release ; produced by Keinosuke Kubo ; screenplay by Ichoro Ikeda Tadaaki Yamazaki ; directed by Seijun Suzuki."] }
+    context "245 field has a slash" do
+      it "does not display slashes" do
+        expected = { "title_with_subtitle_display" => ["Yaju no seishun Youth of the beast"] }
         expect(subject.map_record(records[2])).to eq(expected)
       end
     end
 
     context "title not found with limited selection" do
       it "uses 245A_TO_Z selection" do
-        expected = { "title_statement_display" => ["[video recording]"] }
+        expected = { "title_with_subtitle_display" => ["[video recording]"] }
         expect(subject.map_record(records[3])).to eq(expected)
       end
     end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe CobIndex::Macros::Custom do
 
     before(:each) do
       subject.instance_eval do
-        to_field "title_with_subtitle_display", extract_title_statement
+        to_field "title_with_subtitle_display", extract_title_and_subtitle
 
         settings do
           provide "marc_source.type", "xml"

--- a/spec/fixtures/marc_files/title_statement_examples.xml
+++ b/spec/fixtures/marc_files/title_statement_examples.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection xmlns='http://www.loc.gov/MARC21/slim' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'>
   <record>
-    <!-- 0. 245 field includes subfield h -->
+    <!-- 0. 245 field subfield a -->
     <datafield ind1="0" ind2="4" tag="245">
       <subfield code="a">Die dritte generation</subfield>
       <subfield code="h">[videorecording] /</subfield>
@@ -15,7 +15,7 @@
     </datafield>
   </record>
   <record>
-    <!-- 2. 245 field does NOT display double slashes -->
+    <!-- 2. 245 field does NOT display slashes -->
     <datafield ind1="0" ind2="4" tag="245">
       <subfield code="a">Yaju no seishun</subfield>
       <subfield code="b">Youth of the beast /</subfield>


### PR DESCRIPTION
* Adds new fields (title_with_subtitle_display,  responsibility_display, title_with_subtitle_vern_display, responsibility_vern_display, title_with_subtitle_truncated_display, and responsibility_truncated_display)
* Strips trailing slash and whitespace when a subfield "c" is present
* Updates specs to match new expectations
* For now, leaving the old title_statement fields in the code.  They will be removed as part of future work.