### PR TITLE
BL-1731: Add generic booster.

### DIFF
--- a/lib/cob_index.rb
+++ b/lib/cob_index.rb
@@ -15,4 +15,6 @@ module CobIndex
   autoload :Util, "cob_index/util"
 
   Array.include CoreExtensions::Array::Transformation
+
+  GENRE_FACET_SPEC = "600v:610v:611v:630v:648v:650v:651v:655av:647v"
 end

--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -16,6 +16,9 @@ extend CobIndex::Macros::MarcFormats
 # Include custom traject macros
 extend CobIndex::Macros::Custom
 
+# Include boosting macros
+extend CobIndex::Macros::Booster
+
 CORPORATE_NAMES = CobIndex::Util.load_list_file("corporate_names")
 
 settings(&CobIndex::DefaultConfig.indexer_settings)
@@ -240,7 +243,11 @@ to_field "changed_back_to_display", extract_marc("785|08|iabdghkmnopqrstuxyz3", 
 # Boost records with holdings from specific libraries
 # we actually want to negative boost specific libraries, but that is not possible
 # so we are going to boost everything except the less relevant libraries
+# TODO: Remove library_based_boost_t once the generic boosting is in production and working.
 to_field "library_based_boost_t", library_based_boost
+
+# Allows label specific boost.
+to_field "boost_t", add_boost_labels
 
 to_field "bound_with_ids", extract_marc("ADFa")
 to_field "purchase_order", extract_purchase_order

--- a/lib/cob_index/macros.rb
+++ b/lib/cob_index/macros.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module CobIndex::Macros
+  autoload :Booster, "cob_index/macros/booster"
   autoload :Custom, "cob_index/macros/custom"
   autoload :Marc21, "cob_index/macros/marc21"
   autoload :MarcFormats, "cob_index/macros/marc_format_classifier"

--- a/lib/cob_index/macros/booster.rb
+++ b/lib/cob_index/macros/booster.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "traject"
+
+# This module has macros and methods related to boosting labels and fields.
+
+module CobIndex::Macros::Booster
+  # By convention we append "inverse_boost" or "boost" to the start of the labels as a signal to intent.
+  # Of course, how the label is actually being used depends on what is happening in the Solr configuration,
+  # or the query context.
+  def add_boost_labels
+    lambda do |rec, acc|
+      add_libraries_labels(rec, acc)
+      add_booksellers_labels(rec, acc)
+    end
+  end
+
+  private
+
+    def add_libraries_labels(rec, acc)
+      extractor = Traject::MarcExtractor.cached("HLDb")
+      libraries = extractor.extract(rec)
+
+      # In ruby [].all? is true
+      return if libraries.empty?
+
+      if libraries.all? { |l| [ "PRESSER", "CLAEDTECH" ].include? l }
+        acc << "inverse_boost_libraries"
+      end
+    end
+
+    def add_booksellers_labels(rec, acc)
+      extractor = Traject::MarcExtractor.cached(CobIndex::GENRE_FACET_SPEC)
+      genres = extractor.extract(rec)
+
+      return if genres.empty?
+      acc << "inverse_boost_bookseller" if genres.any? { |g| g.match(/Bookseller/i) }
+    end
+end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -471,7 +471,7 @@ module CobIndex::Macros::Custom
 
   def extract_genre
     lambda do |rec, acc|
-      Traject::MarcExtractor.cached("600v:610v:611v:630v:648v:650v:651v:655av:647v").collect_matching_lines(rec) do |field, spec, extractor|
+      Traject::MarcExtractor.cached(CobIndex::GENRE_FACET_SPEC).collect_matching_lines(rec) do |field, spec, extractor|
         genre = extractor.collect_subfields(field, spec).first
         unless genre.nil?
           unless GENRE_STOP_WORDS.match(genre.force_encoding(Encoding::UTF_8).unicode_normalize)

--- a/spec/cob_index/macros/booster_spec.rb
+++ b/spec/cob_index/macros/booster_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require "rspec"
+require "cob_index"
+include CobIndex::Macros::Booster
+
+
+RSpec.describe CobIndex::Macros::Booster do
+  let(:test_class) do
+    Class.new(Traject::Indexer)
+  end
+
+  let(:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
+
+  subject { test_class.new }
+
+
+  describe "#add_boost_labels" do
+
+    before :each do
+      subject.instance_eval do
+        to_field "boost", add_boost_labels
+        settings do
+          provide "marc_source.type", "xml"
+        end
+      end
+    end
+
+    context "all bad libraries" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2='0' tag='HLD'>
+            <subfield code='b'>PRESSER</subfield>
+          </datafield>
+        </record>
+      " }
+
+      it "adds the inverse_boost_libraries label" do
+        expect(subject.map_record(record)).to eq("boost" => ["inverse_boost_libraries"])
+      end
+    end
+
+    context "all bad libraries multi" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2='0' tag='HLD'>
+            <subfield code='b'>PRESSER</subfield>
+          </datafield>
+          <datafield ind1=' ' ind2='0' tag='HLD'>
+            <subfield code='b'>CLAEDTECH</subfield>
+          </datafield>
+        </record>
+      " }
+
+      it "adds the inverse_boost_libraries label" do
+        expect(subject.map_record(record)).to eq("boost" => ["inverse_boost_libraries"])
+      end
+    end
+
+    context "only some bad libraries multi" do
+      let(:record_text) { "
+        <record>
+          <datafield ind1=' ' ind2='0' tag='HLD'>
+            <subfield code='b'>PRESSER</subfield>
+          </datafield>
+          <datafield ind1=' ' ind2='0' tag='HLD'>
+            <subfield code='b'>FOO</subfield>
+          </datafield>
+        </record>
+      " }
+
+      it "adds the inverse_boost_libraries label" do
+        expect(subject.map_record(record)).to eq({})
+      end
+    end
+
+    context "when genre value matches Bookseller" do
+      let(:record_text)  { <<-EOT
+      <record xmlns="http://www.loc.gov/MARC21/slim">
+        <datafield ind1=" " ind2="0" tag="655">
+          <subfield code="a">Bookseller</subfield>
+        </datafield>
+        <datafield ind1=" " ind2="0" tag="655">
+        <subfield code="a">Illegal aliens.</subfield>
+          <subfield code="x">Southern States </subfield>
+        </datafield>
+      </record>
+      EOT
+      }
+
+      it "adds inverse_boost_bookseller label" do
+        expect(subject.map_record(record)).to eq("boost" => ["inverse_boost_bookseller"])
+      end
+    end
+
+    context "when genre value does not match Bookseller" do
+      let(:record_text)  { <<-EOT
+      <record xmlns="http://www.loc.gov/MARC21/slim">
+        <datafield ind1=" " ind2="0" tag="655">
+        <subfield code="a">Illegal aliens.</subfield>
+          <subfield code="x">Southern States </subfield>
+        </datafield>
+      </record>
+      EOT
+      }
+
+      it "does not add inverse_boost_bookseller label" do
+        expect(subject.map_record(record)).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds new macro for boosting based on labels.

Adds label for inverse boosting on bad_libraries label.
Adds label for inverse boosting on bookseller label.