### PR TITLE
Refactor flank macro.

### DIFF
--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -646,7 +646,10 @@ module CobIndex::Macros::Custom
     starts ||= "matchbeginswith"
     ends ||= "matchendswith"
     if !string.to_s.empty? && !string.match(/^#{starts}/)
-      "#{starts} #{string} #{ends}"
+
+      first_word = string.split.first
+      last_word = string.split.last
+      "#{starts}#{first_word} #{string} #{ends}#{last_word}"
     else
       string
     end

--- a/spec/cob_index/indexer_config_spec.rb
+++ b/spec/cob_index/indexer_config_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Traject configuration" do
       " }
 
       it "removes the unwanted corp" do
-        expect(indexer.map_record(record)["creator_t"]).to eq(["matchbeginswith FOO matchendswith"])
+        expect(indexer.map_record(record)["creator_t"]).to eq(["matchbeginswithFOO FOO matchendswithFOO"])
       end
     end
   end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe "custom methods" do
     end
 
     context "non empty string" do
-      let(:input) { "foo" }
+      let(:input) { "foo bar buzz" }
       it "returns a flanked string" do
-        expect(subject).to eq("matchbeginswith foo matchendswith")
+        expect(subject).to eq("matchbeginswithfoo foo bar buzz matchendswithbuzz")
       end
     end
 
     context "a string that is flanked" do
-      let(:input) { "matchbeginswith foo matchendswith" }
+      let(:input) { "matchbeginswithfoo foo bar buzz matchendswithbar" }
       it "does not reflank a string" do
         expect(subject).to eq(input)
       end


### PR DESCRIPTION
The flank macro is used to add a token to the beginning  and end of
a string that is going to be indexed. But, with the version this change
fixes, that token is always the same and for Solr tokenizers that split on
white spaces it's essentially lost in the shuffle (just another token).

By updating the macro to create a token that embeds more information
about what exactly a string begins with and a string endswith we can
include the specific token to pull the desired results.
``