### PR TITLE
Refactor flank macro.

### DIFF
--- a/lib/cob_index/indexer_config.rb
+++ b/lib/cob_index/indexer_config.rb
@@ -19,6 +19,8 @@ extend CobIndex::Macros::Custom
 # Include boosting macros
 extend CobIndex::Macros::Booster
 
+extend CobIndex::Macros::Wrapper
+
 CORPORATE_NAMES = CobIndex::Util.load_list_file("corporate_names")
 
 settings(&CobIndex::DefaultConfig.indexer_settings)

--- a/lib/cob_index/macros.rb
+++ b/lib/cob_index/macros.rb
@@ -3,6 +3,7 @@
 module CobIndex::Macros
   autoload :Booster, "cob_index/macros/booster"
   autoload :Custom, "cob_index/macros/custom"
+  autoload :Wrapper, "cob_index/macros/wrapper"
   autoload :Marc21, "cob_index/macros/marc21"
   autoload :MarcFormats, "cob_index/macros/marc_format_classifier"
 end

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -636,25 +636,6 @@ module CobIndex::Macros::Custom
     end
   end
 
-  def wrap_begin_end(*args)
-    lambda do |record, accumulator, context|
-      accumulator.map! { |v| flank v }
-    end
-  end
-
-  def flank(string = "", starts = nil, ends = nil)
-    starts ||= "matchbeginswith"
-    ends ||= "matchendswith"
-    if !string.to_s.empty? && !string.match(/^#{starts}/)
-
-      first_word = string.split.first
-      last_word = string.split.last
-      "#{starts}#{first_word} #{string} #{ends}#{last_word}"
-    else
-      string
-    end
-  end
-
   def suppress_items
     lambda do |rec, acc, context|
       full_text_link = rec.fields("856").select { |field| field["u"] }

--- a/lib/cob_index/macros/custom.rb
+++ b/lib/cob_index/macros/custom.rb
@@ -646,7 +646,10 @@ module CobIndex::Macros::Custom
     starts ||= "matchbeginswith"
     ends ||= "matchendswith"
     if !string.to_s.empty? && !string.match(/^#{starts}/)
-      "#{starts} #{string} #{ends}"
+
+      first_word = string.split.first
+      last_word = string.split.last
+      "#{starts}#{first_word} #{string} #{ends}#{last_word}"
     else
       string
     end

--- a/lib/cob_index/macros/wrapper.rb
+++ b/lib/cob_index/macros/wrapper.rb
@@ -1,0 +1,37 @@
+
+# frozen_string_literal: true
+
+module CobIndex::Macros::Wrapper
+
+  START_MATCHER = "matchbeginswith"
+  END_MATCHER = "matchendswith"
+
+  def wrap_begin_end(*args)
+    lambda do |record, accumulator, context|
+      accumulator.map! { |v| self.flank v }
+    end
+  end
+
+
+  def first_word_matcher(string="", start_matcher = START_MATCHER)
+    start_matcher + string.to_s.split.first.to_s
+  end
+
+  def last_word_matcher(string="", end_matcher = END_MATCHER)
+    end_matcher + string.to_s.split.last.to_s
+  end
+
+  def flank(string = "", starts = nil, ends = nil)
+    starts ||= START_MATCHER
+    ends ||= END_MATCHER
+
+    first_word = first_word_matcher(string, starts)
+    last_word = last_word_matcher(string, ends)
+
+    if !string.to_s.empty? && !string.match(/^#{starts}/)
+      "#{first_word} #{string} #{last_word}"
+    else
+      string
+    end
+  end
+end

--- a/spec/cob_index/indexer_config_spec.rb
+++ b/spec/cob_index/indexer_config_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe "Traject configuration" do
       " }
 
       it "removes the unwanted corp" do
-        expect(indexer.map_record(record)["creator_t"]).to eq(["matchbeginswith FOO matchendswith"])
+        expect(indexer.map_record(record)["creator_t"]).to eq(["matchbeginswithFOO FOO matchendswithFOO"])
       end
     end
   end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe "custom methods" do
     end
 
     context "non empty string" do
-      let(:input) { "foo" }
+      let(:input) { "foo bar buzz" }
       it "returns a flanked string" do
-        expect(subject).to eq("matchbeginswith foo matchendswith")
+        expect(subject).to eq("matchbeginswithfoo foo bar buzz matchendswithbuzz")
       end
     end
 
     context "a string that is flanked" do
-      let(:input) { "matchbeginswith foo matchendswith" }
+      let(:input) { "matchbeginswithfoo foo bar buzz matchendswithbar" }
       it "does not reflank a string" do
         expect(subject).to eq(input)
       end

--- a/spec/cob_index/macros/custom_spec.rb
+++ b/spec/cob_index/macros/custom_spec.rb
@@ -54,37 +54,6 @@ RSpec.describe "custom methods" do
     end
   end
 
-  describe "#flank(field)" do
-    let(:input) {}
-    subject { CobIndex::Macros::Custom.flank input }
-    context "nil" do
-      it "returns an empty string" do
-        expect(subject).to be_nil
-      end
-    end
-
-    context "empty string" do
-      let(:input) { "" }
-      it "returns an empty string" do
-        expect(subject).to eq("")
-      end
-    end
-
-    context "non empty string" do
-      let(:input) { "foo bar buzz" }
-      it "returns a flanked string" do
-        expect(subject).to eq("matchbeginswithfoo foo bar buzz matchendswithbuzz")
-      end
-    end
-
-    context "a string that is flanked" do
-      let(:input) { "matchbeginswithfoo foo bar buzz matchendswithbar" }
-      it "does not reflank a string" do
-        expect(subject).to eq(input)
-      end
-    end
-  end
-
   describe "#creator_name_trim_punctuation(name)" do
     context "removes trailing comma, slash" do
       let(:input) { "Richard M. Restak." }

--- a/spec/cob_index/macros/wrapper_spec.rb
+++ b/spec/cob_index/macros/wrapper_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+
+require "rspec"
+require "cob_index/macros/wrapper"
+
+include CobIndex::Macros::Wrapper
+
+RSpec.describe CobIndex::Macros::Wrapper  do
+
+  describe "#flank(field)" do
+    let(:input) {}
+    subject { CobIndex::Macros::Wrapper.flank input }
+    context "nil" do
+      it "returns an empty string" do
+        expect(subject).to be_nil
+      end
+    end
+
+    context "empty string" do
+      let(:input) { "" }
+      it "returns an empty string" do
+        expect(subject).to eq("")
+      end
+    end
+
+    context "non empty string" do
+      let(:input) { "foo bar buzz" }
+      it "returns a flanked string" do
+        expect(subject).to eq("matchbeginswithfoo foo bar buzz matchendswithbuzz")
+      end
+    end
+
+    context "a string that is flanked" do
+      let(:input) { "matchbeginswithfoo foo bar buzz matchendswithbar" }
+      it "does not reflank a string" do
+        expect(subject).to eq(input)
+      end
+    end
+  end
+end


### PR DESCRIPTION
* The flank macro is used to add a token to the beginning  and end of a
string that is going to be indexed. But, with the version this change 
fixes, that token is always the same and for Solr tokenizers that split on 
white spaces it's essentially lost in the shuffle (just another token).

By updating the macro to create a token that embeds more information about
what exactly a string begins with and a string endswith we can include the
specific token to pull the desired results.


* Moves flank/wrapper methods to new module to use in tul_cob.


``