### PR TITLE
Fix delete command not working.

### DIFF
--- a/lib/cob_index/cli.rb
+++ b/lib/cob_index/cli.rb
@@ -23,7 +23,7 @@ module CobIndex::CLI
       if suppress
         "suppress_config"
       else
-        "deletes_config"
+        "delete_config"
       end
     indexer.load_config_file("#{File.dirname(__FILE__)}/#{config}.rb")
     indexer.process(StringIO.new(xml))

--- a/spec/cob_index_spec.rb
+++ b/spec/cob_index_spec.rb
@@ -80,9 +80,9 @@ RSpec.describe CobIndex do
 
     context "suppress switch is not set" do
       it "loads the deleles_config" do
-        deletes_config_file = "#{File.dirname(__FILE__)}/cob_index/deletes_config.rb"
+        delete_config_file = "#{File.dirname(__FILE__)}/cob_index/delete_config.rb"
           .sub("/spec/", "/lib/")
-        expect(@indexer).to receive(:load_config_file).with(deletes_config_file)
+        expect(@indexer).to receive(:load_config_file).with(delete_config_file)
       end
     end
 


### PR DESCRIPTION
The delete command only seems to work when is used as supress not when it's used to delete.

This changes fixes the file not found error when it is not used to supress.