### PR TITLE
BL-1763: increase the time out.

### DIFF
--- a/lib/cob_index/default_config.rb
+++ b/lib/cob_index/default_config.rb
@@ -22,7 +22,7 @@ module CobIndex::DefaultConfig
       provide "solr.url", solr_url
       provide "solr_writer.commit_on_close", false
       provide "writer_class_name", "CobIndex::SolrJsonWriter"
-      provide "solr_writer.http_timeout", 300
+      provide "solr_writer.http_timeout", 400
 
       if ENV["SOLR_AUTH_USER"] && ENV["SOLR_AUTH_PASSWORD"]
         provide "solr_writer.basic_auth_user", ENV["SOLR_AUTH_USER"]


### PR DESCRIPTION
I noticed that for full reindexing task, it can take more than 300s per file.

I'm increasing the timeout here to avoid timeout issues in the full reindexing task.