### PR TITLE
BL-1943 Updates methods related to new subject translations

### DIFF
--- a/lib/translation_maps/subject_remediation.yaml
+++ b/lib/translation_maps/subject_remediation.yaml
@@ -1,16 +1,17 @@
-"Aliens": Noncitizens
-"Illegal aliens": Undocumented immigrants
-"Alien criminals": Noncitizen criminals
-"Alien detention centers": Noncitizen detention centers
-"Alien property": Noncitizen property
-"Aliens in art": Noncitizens in art
-"Aliens in literature": Noncitizens in literature
-"Aliens in mass media": Noncitizens in mass media
-"Aliens in motion pictures": Noncitizens in motion pictures
-"Children of illegal aliens": Children of undocumented immigrants
-"Church work with aliens": Church work with noncitizens
-"Illegal alien children": Undocumented immigrant children
-"Illegal aliens in literature": Undocumented immigrants in literature
-"Women illegal aliens": Women undocumented immigrants
-"America, Gulf of": Mexico, Gulf of
-"McKinley, Mount": Denali, Mount
+"aliens": Noncitizens
+"illegal aliens": Undocumented immigrants
+"alien criminals": Noncitizen criminals
+"alien detention centers": Noncitizen detention centers
+"alien property": Noncitizen property
+"aliens in art": Noncitizens in art
+"aliens in literature": Noncitizens in literature
+"aliens in mass media": Noncitizens in mass media
+"aliens in motion pictures": Noncitizens in motion pictures
+"children of illegal aliens": Children of undocumented immigrants
+"church work with aliens": Church work with noncitizens
+"illegal alien children": Undocumented immigrant children
+"illegal aliens in literature": Undocumented immigrants in literature
+"women illegal aliens": Women undocumented immigrants
+"america, gulf of": Mexico, Gulf of
+"mckinley, mount": Denali, Mount
+"mckinley, mount (Alaska)": Denali, Mount (Alaska)


### PR DESCRIPTION
* Normalizes subjects before translation to handle casing issues
* Removes subfield $0 from displaying
* Removes marc 043 from displaying
* Adds additional translations to map