### PR TITLE
BL-1943 Add more translations to map

### DIFF
--- a/lib/translation_maps/subject_remediation.yaml
+++ b/lib/translation_maps/subject_remediation.yaml
@@ -13,5 +13,7 @@
 "illegal aliens in literature": Undocumented immigrants in literature
 "women illegal aliens": Women undocumented immigrants
 "america, gulf of": Mexico, Gulf of
+"america, gulf of.": Mexico, Gulf of
+"watershed, gulf of": Mexico, Gulf of
 "mckinley, mount": Denali, Mount
 "mckinley, mount (Alaska)": Denali, Mount (Alaska)

--- a/spec/cob_index/macros/subject_spec.rb
+++ b/spec/cob_index/macros/subject_spec.rb
@@ -125,6 +125,27 @@ RSpec.describe CobIndex::Macros::Subject do
       end
     end
 
+    context "when translatable subject is present in 651a with punctuation" do
+
+      let(:record_text) do
+        <<-EOT
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <datafield ind1=" " ind2="0" tag="651">
+            <subfield code="a">America, Gulf of.</subfield>
+          </datafield>#{'  '}
+        </record>
+        EOT
+      end
+
+      let(:record) { MARC::XMLReader.new(StringIO.new(record_text)).first }
+
+      it "translates subject" do
+        expect(subject.map_record(record)["subject_display"]).to eq([
+          "Mexico, Gulf of"
+        ])
+      end
+    end
+
     context "when a non-translatable subject is present in 650a with punctuation" do
       let(:record_text) do
         <<-EOT
@@ -368,9 +389,12 @@ RSpec.describe CobIndex::Macros::Subject do
       let(:record_text) do
         <<-EOT
         <record xmlns="http://www.loc.gov/MARC21/slim">
+          <datafield ind1=" " ind2="0" tag="651">
+            <subfield code="a">America, Gulf of.</subfield>
+          </datafield>
           <datafield ind1=" " ind2="0" tag="650">
             <subfield code="a">Navigation</subfield>
-            <subfield code="z">America, Gulf of</subfield>
+            <subfield code="z">Watershed, Gulf of</subfield>
             <subfield code="x">History.</subfield>
           </datafield>
         </record>


### PR DESCRIPTION
This adds more translations to the map.  I had to explicitly add america, gulf of. to the map because the trim_punctuation method treats of as an abbreviation and won't strip the trailing period.